### PR TITLE
switch from relative to absolute links in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 #
 # import os
 # import sys
-# sys.path.insert(0, os.path.abspath('../'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,10 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-
-import os
-import sys
-sys.path.insert(0, os.path.abspath('../'))
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,10 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -449,4 +449,4 @@ If you would like to contribute to this project, please see our `contribution gu
 License
 -------
 
-.. include:: ../../LICENSE
+.. include:: ../LICENSE

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,7 +443,7 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our :doc:`contribution guidelines <../../CONTRIBUTING.md>`.
+If you would like to contribute to this project, please see our :download:`contribution guidelines <../CONTRIBUTING.md>`.
 
 
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,10 +443,10 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our `contribution guidelines <../../CONTRIBUTING.md>`_.
+If you would like to contribute to this project, please see our `contribution guidelines <https://github.com/spine-generic/spine-generic/blob/master/CONTRIBUTING.md>`_.
 
 
 License
 -------
 
-See the file `LICENSE <../../LICENSE>`_.
+See the file `LICENSE <https://github.com/spine-generic/spine-generic/blob/master/LICENSE>`_.

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,7 +443,9 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our `contribution guidelines <../CONTRIBUTING.md>`_.
+If you would like to contribute to this project, please see our contribution `guidelines`_. 
+
+.. _guidelines: ../CONTRIBUTING.md
 
 
 License

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -449,4 +449,4 @@ If you would like to contribute to this project, please see our `contribution gu
 License
 -------
 
-See the file `LICENSE <../LICENSE>`_.
+.. include:: ../../LICENSE

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -442,10 +442,10 @@ folder `results/`:
 Contributors
 ------------
 
-A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see: 
+:download:`../CONTRIBUTING.md`
 
-.. include:: ../CONTRIBUTING.md
+A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
+If you would like to contribute to this project, please see `contribution guidelines <_downloads/CONTRIBUTING.md>`__.
 
 
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,7 +443,9 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our :download:`contribution guidelines <../CONTRIBUTING.md>`.
+If you would like to contribute to this project, please see: 
+
+.. include:: ../CONTRIBUTING.md
 
 
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,9 +443,8 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our contribution `guidelines`_. 
+If you would like to contribute to this project, please see our :doc:`contribution guidelines <../../CONTRIBUTING.md>`.
 
-.. _guidelines: ../CONTRIBUTING.md
 
 
 License

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -443,10 +443,10 @@ Contributors
 ------------
 
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see our `contribution guidelines <https://github.com/spine-generic/spine-generic/blob/master/CONTRIBUTING.md>`_.
+If you would like to contribute to this project, please see our `contribution guidelines <../CONTRIBUTING.md>`_.
 
 
 License
 -------
 
-See the file `LICENSE <https://github.com/spine-generic/spine-generic/blob/master/LICENSE>`_.
+See the file `LICENSE <../LICENSE>`_.

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -442,10 +442,8 @@ folder `results/`:
 Contributors
 ------------
 
-:download:`../CONTRIBUTING.md`
-
 A list of contributors for the analysis pipeline is available `here <https://github.com/spine-generic/spine-generic/graphs/contributors>`__.
-If you would like to contribute to this project, please see `contribution guidelines <_downloads/CONTRIBUTING.md>`__.
+If you would like to contribute to this project, please see `contribution guidelines <https://github.com/spine-generic/spine-generic/blob/master/CONTRIBUTING.md>`_.
 
 
 


### PR DESCRIPTION
Built doc on this branch: https://spine-generic.readthedocs.io/en/jv-100-broken_relative_link_fix

Fix: #100 