### PR TITLE
Look for manual files under derivatives/

### DIFF
--- a/processing/process_data.sh
+++ b/processing/process_data.sh
@@ -12,7 +12,7 @@
 # PATH_QC="~/qc"
 
 # Uncomment for full verbose
-#set -v
+set -x
 
 # Immediately exit if error
 set -e -o pipefail
@@ -52,7 +52,6 @@ get_field_from_json(){
 
 # Check if manual label already exists. If it does, copy it locally. If it does
 # not, perform labeling.
-# TODO: rename to "label" and remove the duplication in this script
 label_if_does_not_exist(){
   local file="$1"
   local file_seg="$2"

--- a/processing/process_data.sh
+++ b/processing/process_data.sh
@@ -77,7 +77,6 @@ segment_if_does_not_exist(){
   local file="$1"
   local contrast="$2"
   # Find contrast
-  contrast=`cut -d "_" -f2 <<< $file`
   if [ $contrast == "dwi" ]; then
     folder_contrast="dwi"
   else

--- a/processing/process_data.sh
+++ b/processing/process_data.sh
@@ -12,7 +12,7 @@
 # PATH_QC="~/qc"
 
 # Uncomment for full verbose
-set -v
+#set -v
 
 # Immediately exit if error
 set -e -o pipefail
@@ -52,16 +52,17 @@ get_field_from_json(){
 
 # Check if manual label already exists. If it does, copy it locally. If it does
 # not, perform labeling.
+# TODO: rename to "label" and remove the duplication in this script
 label_if_does_not_exist(){
   local file="$1"
   local file_seg="$2"
   # Update global variable with segmentation file name
   FILELABEL="${file}_labels"
-  FILELABELMANUAL="${PATH_SEGMANUAL}/${file}_labels-manual.nii.gz"
+  FILELABELMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILELABEL}-manual.nii.gz"
   echo "Looking for manual label: $FILELABELMANUAL"
   if [ -e $FILELABELMANUAL ]; then
     echo "Found! Using manual labels."
-    rsync -avzh $FILELABELMANUA ${FILELABEL}.nii.gz
+    rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
   else
     echo "Not found. Proceeding with automatic labeling."
     # Generate labeled segmentation
@@ -78,7 +79,8 @@ segment_if_does_not_exist(){
   local contrast="$2"
   # Update global variable with segmentation file name
   FILESEG="${file}_seg"
-  FILESEGMANUAL="${PATH_SEGMANUAL}/${FILESEG}-manual.nii.gz"
+  FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILESEG}-manual.nii.gz"
+  echo
   echo "Looking for manual segmentation: $FILESEGMANUAL"
   if [ -e $FILESEGMANUAL ]; then
     echo "Found! Using manual segmentation."
@@ -98,7 +100,7 @@ segment_gm_if_does_not_exist(){
   local contrast="$2"
   # Update global variable with segmentation file name
   FILESEG="${file}_gmseg"
-  FILESEGMANUAL="${PATH_SEGMANUAL}/${FILESEG}-manual.nii.gz"
+  FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILESEG}-manual.nii.gz"
   echo "Looking for manual segmentation: $FILESEGMANUAL"
   if [ -e $FILESEGMANUAL ]; then
     echo "Found! Using manual segmentation."
@@ -125,6 +127,7 @@ cp $PATH_DATA/participants.tsv .
 cp -r $PATH_DATA/$SUBJECT .
 # Go to anat folder where all structural data are located
 cd ${SUBJECT}/anat/
+
 
 # T1w
 # ------------------------------------------------------------------------------

--- a/processing/process_data.sh
+++ b/processing/process_data.sh
@@ -32,7 +32,7 @@ SUBJECT=$1
 concatenate_b0_and_dwi(){
   local file_b0="$1"  # does not have extension
   local file_dwi="$2"  # does not have extension
-  if [ -e ${file_b0}.nii.gz ]; then
+  if [[ -e ${file_b0}.nii.gz ]]; then
     echo "Found additional b=0 scans: $file_b0.nii.gz They will be concatenated to the DWI scans."
     sct_dmri_concat_b0_and_dwi -i ${file_b0}.nii.gz ${file_dwi}.nii.gz -bval ${file_dwi}.bval -bvec ${file_dwi}.bvec -order b0 dwi -o ${file_dwi}_concat.nii.gz -obval ${file_dwi}_concat.bval -obvec ${file_dwi}_concat.bvec
     # Update global variable
@@ -59,7 +59,7 @@ label_if_does_not_exist(){
   FILELABEL="${file}_labels"
   FILELABELMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILELABEL}-manual.nii.gz"
   echo "Looking for manual label: $FILELABELMANUAL"
-  if [ -e $FILELABELMANUAL ]; then
+  if [[ -e $FILELABELMANUAL ]]; then
     echo "Found! Using manual labels."
     rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
   else
@@ -77,7 +77,7 @@ segment_if_does_not_exist(){
   local file="$1"
   local contrast="$2"
   # Find contrast
-  if [ $contrast == "dwi" ]; then
+  if [[ $contrast == "dwi" ]]; then
     folder_contrast="dwi"
   else
     folder_contrast="anat"
@@ -87,7 +87,7 @@ segment_if_does_not_exist(){
   FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/${folder_contrast}/${FILESEG}-manual.nii.gz"
   echo
   echo "Looking for manual segmentation: $FILESEGMANUAL"
-  if [ -e $FILESEGMANUAL ]; then
+  if [[ -e $FILESEGMANUAL ]]; then
     echo "Found! Using manual segmentation."
     rsync -avzh $FILESEGMANUAL ${FILESEG}.nii.gz
     sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_sc -qc ${PATH_QC} -qc-subject ${SUBJECT}
@@ -107,7 +107,7 @@ segment_gm_if_does_not_exist(){
   FILESEG="${file}_gmseg"
   FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILESEG}-manual.nii.gz"
   echo "Looking for manual segmentation: $FILESEGMANUAL"
-  if [ -e $FILESEGMANUAL ]; then
+  if [[ -e $FILESEGMANUAL ]]; then
     echo "Found! Using manual segmentation."
     rsync -avzh $FILESEGMANUAL ${FILESEG}.nii.gz
     sct_qc -i ${file}.nii.gz -s ${FILESEG}.nii.gz -p sct_deepseg_gm -qc ${PATH_QC} -qc-subject ${SUBJECT}
@@ -300,7 +300,7 @@ FILES_TO_CHECK=(
   "dwi/label/atlas/PAM50_atlas_00.nii.gz"
 )
 for file in ${FILES_TO_CHECK[@]}; do
-  if [ ! -e $file ]; then
+  if [[ ! -e $file ]]; then
     echo "${SUBJECT}/${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
   fi
 done

--- a/processing/process_data.sh
+++ b/processing/process_data.sh
@@ -76,9 +76,16 @@ label_if_does_not_exist(){
 segment_if_does_not_exist(){
   local file="$1"
   local contrast="$2"
+  # Find contrast
+  contrast=`cut -d "_" -f2 <<< $file`
+  if [ $contrast == "dwi" ]; then
+    folder_contrast="dwi"
+  else
+    folder_contrast="anat"
+  fi
   # Update global variable with segmentation file name
   FILESEG="${file}_seg"
-  FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/anat/${FILESEG}-manual.nii.gz"
+  FILESEGMANUAL="${PATH_DATA}/derivatives/${SUBJECT}/${folder_contrast}/${FILESEG}-manual.nii.gz"
   echo
   echo "Looking for manual segmentation: $FILESEGMANUAL"
   if [ -e $FILESEGMANUAL ]; then


### PR DESCRIPTION
Currently, users have to put all manual seg and label under a flat directory, under a folder called with the flag `PATH_SEGMANUAL` upon calling `sct_run_batch`.  Issues are:
- does not follow BIDS convention
- need to manually package the manual corrections and upload them for each release
- more complicated UX and documentation

This PR introduces the following changes:
- manual corrections go inside the BIDS dataset, under a `derivatives/` folder
- `process_data.sh` is modified to look for the manual corrections there

Fixes #3

Remaining TODOs (after merging this PR):
- update documentation (related to https://github.com/spine-generic/spine-generic/pull/103)
- upload manual corrections under derivatives/: https://github.com/spine-generic/spine-generic/issues/105