### PR TITLE
Create json sidecar

### DIFF
--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -56,9 +56,7 @@ def get_parser():
             - sub-amu01_T2star_rms.nii.gz
             FILES_LABEL:
             - sub-amu01_T1w_RPI_r.nii.gz
-            - sub-amu02_T1w_RPI_r.nii.gz
-            NAME:
-            - John Doe\n
+            - sub-amu02_T1w_RPI_r.nii.gz\n
             """)
     )
     parser.add_argument(


### PR DESCRIPTION
This PR introduces the creation of a json sidecar file, along with each corrected segmentation or label. This json includes the expert rater name and date of the correction. The name is entered (used is prompted on the CLI) when running `sg_manual_correction`.

Example of created json:

````json
{
    "Author": "Julien Cohen-Adad",
    "Date": "2020-07-22 12:04:47"
}
````

Fixes #143