### PR TITLE
Generate QC report for manual corrections

### DIFF
--- a/docs/analysis_pipeline.rst
+++ b/docs/analysis_pipeline.rst
@@ -153,6 +153,13 @@ and open an interactive window for you to either correct the segmentation, or pe
 manually-corrected label is saved under the ``derivatives/labels/`` folder at the root of ``<PATH_DATA>``,
 according to the BIDS convention. The manually-corrected label files have the suffix ``-manual``.
 
+Your name will be asked at the beginning, and will be recorded in the .json files that accompany the corrected labels.
+
+A QC report of all the manual correction will be created locally and archived as a zip file. To update the
+database with the manual corrections (using git), create a pull request and upload the QC report directly in the pull
+request so the admin team can easily review the proposed changes. If the team accepts the pull request, a new release
+of the dataset will be created and the zipped QC report will be uploaded as a release object.
+
 .. note::
 
    In case processing is ran on a remote cluster, it it convenient to generate a package of the files that need

--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -193,18 +193,24 @@ def main():
     name_rater = input("Enter your name (Firstname Lastname). It will be used to generate a json sidecar with each "
                        "corrected file: ")
 
+    # Build QC report folder name
+    fname_qc = 'qc_corr_' + time.strftime('%Y%m%d%H%M%S')
+
     # Perform manual corrections
     for task, files in dict_yml.items():
         for file in files:
             if task == 'FILES_SEG':
-                correct_segmentation(file, args.path_in, path_out_deriv, name_rater=name_rater)
+                correct_segmentation(file, args.path_in, path_out_deriv, name_rater=name_rater, fname_qc=fname_qc)
             elif task == 'FILES_GMSEG':
-                correct_segmentation(file, args.path_in, path_out_deriv, type_seg='graymatter', name_rater=name_rater)
+                correct_segmentation(file, args.path_in, path_out_deriv, type_seg='graymatter', name_rater=name_rater,
+                                     fname_qc=fname_qc)
             elif task == 'FILES_LABEL':
-                correct_vertebral_labeling(file, args.path_in, path_out_deriv, name_rater=name_rater)
+                correct_vertebral_labeling(file, args.path_in, path_out_deriv, name_rater=name_rater, fname_qc=fname_qc)
             else:
                 sys.exit('Task not recognized from yml file: {}'.format(task))
 
+    shutil.make_archive(fname_qc, 'zip', fname_qc)
+    print("Archive created:\n--> {}".format(fname_qc+'.zip'))
 
 if __name__ == '__main__':
     main()

--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -138,12 +138,9 @@ def correct_vertebral_labeling(file, path_data, path_out, name_rater='Anonymous'
     os.makedirs(os.path.join(path_out, subject, sg.bids.get_contrast(file)), exist_ok=True)
     # launch SCT label utils
     message = "Click inside the spinal cord, at C3 and C5 mid-vertebral levels, then click 'Save and Quit'."
-    os.system('sct_label_utils -i {} -create-viewer 3,5 -o {} -msg {}'.format(fname, fname_label, message))
+    os.system('sct_label_utils -i {} -create-viewer 3,5 -o {} -msg {} -qc {} -qc-subject {}'.format(
+        fname, fname_label, message, fname_qc, subject))
     create_json(fname_label, name_rater)
-    # generate QC report
-    print("QC report for sct_label_utils not implemented (yet)")
-    # os.system('sct_qc -i {} -s {} -p sct_label_utils -qc {} -qc-subject {}'.format(
-    #     fname, fname_label, fname_qc, subject))
 
 
 def create_json(fname_nifti, name_rater):

--- a/spinegeneric/utils.py
+++ b/spinegeneric/utils.py
@@ -166,6 +166,7 @@ def check_software_installed(list_software=['fsleyes', 'sct']):
         'fsleyes': 'fsleyes --version',
         'sct': 'sct_version'
         }
+    logging.info("Checking if required software are installed...")
     for software in list_software:
         try:
             output = subprocess.check_output(software_cmd[software], shell=True)


### PR DESCRIPTION
In this PR, we introduce the generation of a QC report of manual corrections, which can be uploaded alongside a new release of the spine-generic dataset.  Specific changes include:
- QC report for segmentations and label
- QC report generated locally
- QC report archived as zip file for convenient upload alongside data release on github
- Updated documentation on RTD

Fixes #145
