### PR TITLE
Improve sg_package_for_correction

### DIFF
--- a/spinegeneric/cli/package_for_correction.py
+++ b/spinegeneric/cli/package_for_correction.py
@@ -137,7 +137,10 @@ def main():
 
     # Package to zip file
     print("Creating archive...")
-    fname_archive = shutil.make_archive(args.o, 'zip', path_tmp)
+    root_dir_tmp = os.path.join('/',*path_tmp.split('/')[0:-1])
+    base_dir_name = args.o.split('/')[-1]
+    shutil.move (path_tmp, os.path.join(root_dir_tmp,base_dir_name))
+    fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp,base_dir_name)
     print("-> {}".format(fname_archive))
 
 

--- a/spinegeneric/cli/package_for_correction.py
+++ b/spinegeneric/cli/package_for_correction.py
@@ -137,7 +137,7 @@ def main():
 
     # Package to zip file
     print("Creating archive...")
-    root_dir_tmp = os.path.join('/',*path_tmp.split('/')[0:-1])
+    root_dir_tmp = os.path.split(path_tmp)[0]
     base_dir_name = args.o.split('/')[-1]
     shutil.move(path_tmp, os.path.join(root_dir_tmp, base_dir_name))
     fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp, base_dir_name)

--- a/spinegeneric/cli/package_for_correction.py
+++ b/spinegeneric/cli/package_for_correction.py
@@ -140,7 +140,7 @@ def main():
     root_dir_tmp = os.path.join('/',*path_tmp.split('/')[0:-1])
     base_dir_name = args.o.split('/')[-1]
     shutil.move(path_tmp, os.path.join(root_dir_tmp, base_dir_name))
-    fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp,base_dir_name)
+    fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp, base_dir_name)
     print("-> {}".format(fname_archive))
 
 

--- a/spinegeneric/cli/package_for_correction.py
+++ b/spinegeneric/cli/package_for_correction.py
@@ -139,7 +139,7 @@ def main():
     print("Creating archive...")
     root_dir_tmp = os.path.join('/',*path_tmp.split('/')[0:-1])
     base_dir_name = args.o.split('/')[-1]
-    shutil.move (path_tmp, os.path.join(root_dir_tmp,base_dir_name))
+    shutil.move(path_tmp, os.path.join(root_dir_tmp, base_dir_name))
     fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp,base_dir_name)
     print("-> {}".format(fname_archive))
 

--- a/spinegeneric/cli/package_for_correction.py
+++ b/spinegeneric/cli/package_for_correction.py
@@ -138,8 +138,11 @@ def main():
     # Package to zip file
     print("Creating archive...")
     root_dir_tmp = os.path.split(path_tmp)[0]
-    base_dir_name = args.o.split('/')[-1]
-    shutil.move(path_tmp, os.path.join(root_dir_tmp, base_dir_name))
+    base_dir_name = os.path.split(args.o)[1]
+    new_path_tmp = os.path.join(root_dir_tmp, base_dir_name)
+    if os.path.isdir(new_path_tmp):
+        shutil.rmtree(new_path_tmp)
+    shutil.move(path_tmp, new_path_tmp)
     fname_archive = shutil.make_archive(args.o, 'zip', root_dir_tmp, base_dir_name)
     print("-> {}".format(fname_archive))
 


### PR DESCRIPTION
Redefined root and base directory for the zip creation.

How to test:
```
git checkout af/improve_sg_package_for_correction
pip install -e .
sg_package_for_correction -config PATH_TO_YML -path-in DATASET_DATA/
```
@jcohenadad if it's easier for you to test, I can upload an yml & small dummy dataset. 

Fixes https://github.com/spine-generic/spine-generic/issues/139

Example of an output:
```
(base) alfoi_admin@joplin:~$ sg_package_for_correction -config config.yml -path-in dummy_test/ 
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-chiba750/anat/sub-chiba750_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-chiba750/anat/sub-chiba750_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-chiba750/anat/sub-chiba750_T2w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-chiba750/anat/sub-chiba750_T2w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-douglas/anat/sub-douglas_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-douglas/anat/sub-douglas_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-douglas/anat/sub-douglas_T2w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-douglas/anat/sub-douglas_T2w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpaiyvf34q/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz
Creating archive...
-> /home/alfoi_admin/data_to_correct.zip
(base) alfoi_admin@joplin:~$ unzip data_to_correct.zip 
Archive:  data_to_correct.zip
   creating: data_to_correct/
   creating: data_to_correct/sub-chiba750/
   creating: data_to_correct/sub-douglas/
   creating: data_to_correct/sub-glen/
   creating: data_to_correct/sub-glen/anat/
  inflating: data_to_correct/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz  
  inflating: data_to_correct/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz  
   creating: data_to_correct/sub-douglas/anat/
  inflating: data_to_correct/sub-douglas/anat/sub-douglas_T1w_RPI_r_seg.nii.gz  
  inflating: data_to_correct/sub-douglas/anat/sub-douglas_T1w_RPI_r.nii.gz  
  inflating: data_to_correct/sub-douglas/anat/sub-douglas_T2w_RPI_r.nii.gz  
  inflating: data_to_correct/sub-douglas/anat/sub-douglas_T2w_RPI_r_seg.nii.gz  
   creating: data_to_correct/sub-chiba750/anat/
  inflating: data_to_correct/sub-chiba750/anat/sub-chiba750_T2w_RPI_r.nii.gz  
  inflating: data_to_correct/sub-chiba750/anat/sub-chiba750_T2w_RPI_r_seg.nii.gz  
  inflating: data_to_correct/sub-chiba750/anat/sub-chiba750_T1w_RPI_r.nii.gz  
  inflating: data_to_correct/sub-chiba750/anat/sub-chiba750_T1w_RPI_r_seg.nii.gz  
(base) alfoi_admin@joplin:~$ nano code/spine-generic/spinegeneric/cli/package_for_correction.py 
```
Second example when passing an output name:
```
(base) alfoi_admin@joplin:~$ sg_package_for_correction -config config.yml -path-in dummy_test/ -o ~/to_correct
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-chiba750/anat/sub-chiba750_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-chiba750/anat/sub-chiba750_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-chiba750/anat/sub-chiba750_T2w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-chiba750/anat/sub-chiba750_T2w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-douglas/anat/sub-douglas_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-douglas/anat/sub-douglas_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-douglas/anat/sub-douglas_T2w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-douglas/anat/sub-douglas_T2w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz
-> /mnt/nvme/tmp/tmpomzrz7tn/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz
Creating archive...
-> /home/alfoi_admin/to_correct.zip
(base) alfoi_admin@joplin:~$ unzip to_correct.zip 
Archive:  to_correct.zip
   creating: to_correct/
   creating: to_correct/sub-chiba750/
   creating: to_correct/sub-douglas/
   creating: to_correct/sub-glen/
   creating: to_correct/sub-glen/anat/
  inflating: to_correct/sub-glen/anat/sub-glen_T1w_RPI_r.nii.gz  
  inflating: to_correct/sub-glen/anat/sub-glen_T1w_RPI_r_seg.nii.gz  
   creating: to_correct/sub-douglas/anat/
  inflating: to_correct/sub-douglas/anat/sub-douglas_T1w_RPI_r_seg.nii.gz  
  inflating: to_correct/sub-douglas/anat/sub-douglas_T1w_RPI_r.nii.gz  
  inflating: to_correct/sub-douglas/anat/sub-douglas_T2w_RPI_r.nii.gz  
  inflating: to_correct/sub-douglas/anat/sub-douglas_T2w_RPI_r_seg.nii.gz  
   creating: to_correct/sub-chiba750/anat/
  inflating: to_correct/sub-chiba750/anat/sub-chiba750_T2w_RPI_r.nii.gz  
  inflating: to_correct/sub-chiba750/anat/sub-chiba750_T2w_RPI_r_seg.nii.gz  
  inflating: to_correct/sub-chiba750/anat/sub-chiba750_T1w_RPI_r.nii.gz  
  inflating: to_correct/sub-chiba750/anat/sub-chiba750_T1w_RPI_r_seg.nii.gz  
```