### PR TITLE
Changed slicereg to centermass for DWI registration

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -281,7 +281,7 @@ file_dwi_mean=${file_dwi}_dwi_mean
 segment_if_does_not_exist ${file_dwi_mean} "dwi"
 file_dwi_seg=$FILESEG
 # Register template->dwi (using template-T1w as initial transformation)
-sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -d ${file_dwi_mean}.nii.gz -dseg ${file_dwi_seg}.nii.gz -param step=1,type=seg,algo=slicereg,metric=MeanSquares,smooth=2:step=2,type=im,algo=syn,metric=CC,iter=5,gradStep=0.5 -initwarp ../anat/warp_template2T1w.nii.gz -initwarpinv ../anat/warp_T1w2template.nii.gz
+sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -d ${file_dwi_mean}.nii.gz -dseg ${file_dwi_seg}.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=im,algo=syn,metric=CC,iter=5,gradStep=0.5 -initwarp ../anat/warp_template2T1w.nii.gz -initwarpinv ../anat/warp_T1w2template.nii.gz
 # Rename warping field for clarity
 mv warp_PAM50_t12${file_dwi_mean}.nii.gz warp_template2dwi.nii.gz
 mv warp_${file_dwi_mean}2PAM50_t1.nii.gz warp_dwi2template.nii.gz


### PR DESCRIPTION
In this example from `sub-ubc02`, where motion between odd and even scans created the following "zigzag" patterns:

![image](https://user-images.githubusercontent.com/2482071/88861005-06bf7b80-d1cb-11ea-93fa-246c43c024ec.png)

The current registration parameter is causing problem, as it uses `algo=slicereg` (highly regularized along I-S axis). 

The proposed PR switches to `algo=centermass`.

Comparison in this qc report: [qc.zip](https://github.com/spine-generic/spine-generic/files/4997848/qc.zip)

Related to https://github.com/spine-generic/data-multi-subject/issues/9#issuecomment-665530406

Fixes #153