### PR TITLE
Improve sg_manual_correction

### DIFF
--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -208,7 +208,7 @@ def main():
                 correct_vertebral_labeling(file, args.path_in, path_out_deriv, name_rater=name_rater, fname_qc=fname_qc)
             else:
                 sys.exit('Task not recognized from yml file: {}'.format(task))
-    shutil.copy(fname_yml,fname_qc)
+    shutil.copy(fname_yml, fname_qc)
     shutil.make_archive(fname_qc, 'zip', fname_qc)
     print("Archive created:\n--> {}".format(fname_qc+'.zip'))
 

--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -208,7 +208,7 @@ def main():
                 correct_vertebral_labeling(file, args.path_in, path_out_deriv, name_rater=name_rater, fname_qc=fname_qc)
             else:
                 sys.exit('Task not recognized from yml file: {}'.format(task))
-
+    shutil.copy(fname_yml,fname_qc)
     shutil.make_archive(fname_qc, 'zip', fname_qc)
     print("Archive created:\n--> {}".format(fname_qc+'.zip'))
 


### PR DESCRIPTION
When running sg_manual_correction, the function create a zip archive of the QC folder, the yml file that was used as input (-config) is included.

To test:
```
git checkout af/improve_sg_manual_correction
sg_manual_correction -config PATH_TO_config.yml -path-in PATH_TO_DATA -path-out PATH_TO_DATA_OUTPUT
```

Fixes https://github.com/spine-generic/spine-generic/issues/157