### PR TITLE
Added flag -qc-only; Major refactoring to simplify code

### DIFF
--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -193,33 +193,33 @@ def main():
     # Build QC report folder name
     fname_qc = 'qc_corr_' + time.strftime('%Y%m%d%H%M%S')
 
-    if not args.qc_only:
-        # TODO: address "none" issue if no file present under a key
-        # Perform manual corrections
-        for task, files in dict_yml.items():
-            for file in files:
-                # build file names
-                subject = sg.bids.get_subject(file)
-                contrast = sg.bids.get_contrast(file)
-                fname = os.path.join(args.path_in, subject, contrast, file)
-                fname_label = os.path.join(
-                    path_out_deriv, subject, contrast, sg.utils.add_suffix(file, get_suffix(task, '-manual')))
-                os.makedirs(os.path.join(path_out_deriv, subject, contrast), exist_ok=True)
+    # TODO: address "none" issue if no file present under a key
+    # Perform manual corrections
+    for task, files in dict_yml.items():
+        for file in files:
+            # build file names
+            subject = sg.bids.get_subject(file)
+            contrast = sg.bids.get_contrast(file)
+            fname = os.path.join(args.path_in, subject, contrast, file)
+            fname_label = os.path.join(
+                path_out_deriv, subject, contrast, sg.utils.add_suffix(file, get_suffix(task, '-manual')))
+            os.makedirs(os.path.join(path_out_deriv, subject, contrast), exist_ok=True)
 
-                if not args.qc_only:
-                    if task in ['FILES_SEG', 'FILES_GMSEG']:
-                        fname_seg = sg.utils.add_suffix(fname, get_suffix(task))
-                        shutil.copy(fname_seg, fname_label)
-                        correct_segmentation(fname, fname_label)
-                    elif task == 'FILES_LABEL':
-                        correct_vertebral_labeling(fname, fname_label)
-                    else:
-                        sys.exit('Task not recognized from yml file: {}'.format(task))
+            if not args.qc_only:
+                if task in ['FILES_SEG', 'FILES_GMSEG']:
+                    fname_seg = sg.utils.add_suffix(fname, get_suffix(task))
+                    shutil.copy(fname_seg, fname_label)
+                    correct_segmentation(fname, fname_label)
+                elif task == 'FILES_LABEL':
+                    correct_vertebral_labeling(fname, fname_label)
+                else:
+                    sys.exit('Task not recognized from yml file: {}'.format(task))
                 # create json sidecar with the name of the expert rater
                 create_json(fname_label, name_rater)
-                # generate QC report
-                os.system('sct_qc -i {} -s {} -p {} -qc {} -qc-subject {}'.format(
-                    fname, fname_label, get_function(task), fname_qc, subject))
+
+            # generate QC report
+            os.system('sct_qc -i {} -s {} -p {} -qc {} -qc-subject {}'.format(
+                fname, fname_label, get_function(task), fname_qc, subject))
 
     # Archive QC folder
     shutil.copy(fname_yml, fname_qc)

--- a/spinegeneric/cli/manual_correction.py
+++ b/spinegeneric/cli/manual_correction.py
@@ -204,18 +204,33 @@ def main():
             fname_label = os.path.join(
                 path_out_deriv, subject, contrast, sg.utils.add_suffix(file, get_suffix(task, '-manual')))
             os.makedirs(os.path.join(path_out_deriv, subject, contrast), exist_ok=True)
-
             if not args.qc_only:
-                if task in ['FILES_SEG', 'FILES_GMSEG']:
-                    fname_seg = sg.utils.add_suffix(fname, get_suffix(task))
-                    shutil.copy(fname_seg, fname_label)
-                    correct_segmentation(fname, fname_label)
-                elif task == 'FILES_LABEL':
-                    correct_vertebral_labeling(fname, fname_label)
+                if os.path.isfile(fname_label):
+                    # if corrected file already exists, asks user if they want to overwrite it
+                    answer = None
+                    while answer not in ("y", "n"):
+                        answer = input("WARNING! The file {} already exists. "
+                                       "Would you like to overwrite it? [y/n] ".format(fname_label))
+                        if answer == "y":
+                            do_labeling = True
+                        elif answer == "n":
+                            do_labeling = False
+                        else:
+                            print("Please answer with 'y' or 'n'")
                 else:
-                    sys.exit('Task not recognized from yml file: {}'.format(task))
-                # create json sidecar with the name of the expert rater
-                create_json(fname_label, name_rater)
+                    do_labeling = True
+                # Perform labeling for the specific task
+                if do_labeling:
+                    if task in ['FILES_SEG', 'FILES_GMSEG']:
+                        fname_seg = sg.utils.add_suffix(fname, get_suffix(task))
+                        shutil.copy(fname_seg, fname_label)
+                        correct_segmentation(fname, fname_label)
+                    elif task == 'FILES_LABEL':
+                        correct_vertebral_labeling(fname, fname_label)
+                    else:
+                        sys.exit('Task not recognized from yml file: {}'.format(task))
+                    # create json sidecar with the name of the expert rater
+                    create_json(fname_label, name_rater)
 
             # generate QC report
             os.system('sct_qc -i {} -s {} -p {} -qc {} -qc-subject {}'.format(

--- a/spinegeneric/utils.py
+++ b/spinegeneric/utils.py
@@ -131,10 +131,11 @@ def check_files_exist(dict_files, path_data):
     """
     missing_files = []
     for task, files in dict_files.items():
-        for file in files:
-            fname = os.path.join(path_data, sg.bids.get_subject(file), sg.bids.get_contrast(file), file)
-            if not os.path.exists(fname):
-                missing_files.append(fname)
+        if files is not None:
+            for file in files:
+                fname = os.path.join(path_data, sg.bids.get_subject(file), sg.bids.get_contrast(file), file)
+                if not os.path.exists(fname):
+                    missing_files.append(fname)
     if missing_files:
         logging.error("The following files are missing: \n{}. \nPlease check that the files listed "
                       "in the yaml file and the input path are correct.".format(missing_files))


### PR DESCRIPTION
This PR introduces the following changes to `manual_correction`:
- Added a flag `-qc-only` in the CLI to skip correction, and only generate the QC report. Fixes #159
- Major refactoring to simplify the code and enable the functionality above
- If corrected file already exists, asks user if they want to overwrite it
- Fixes TypeError is key is empty in yml file. Fixes #151 
