### PR TITLE
fix superscript for MD and RD ylabel and remove a.u. unit for MTsat

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -170,10 +170,10 @@ metric_to_label = {
     'csa_t2': 'Cord CSA from T2w [$mm^2$]',
     'csa_gm': 'Gray Matter CSA [$mm^2$]',
     'dti_fa': 'Fractional anisotropy',
-    'dti_md': 'Mean diffusivity [$mm^2.s^-1$]',
-    'dti_rd': 'Radial diffusivity [$mm^2.s^-1$]',
+    'dti_md': 'Mean diffusivity [$mm^2.s^{-1}$]',
+    'dti_rd': 'Radial diffusivity [$mm^2.s^{-1}$]',
     'mtr': 'Magnetization transfer ratio [%]',
-    'mtsat': 'Magnetization transfer saturation [a.u.]',
+    'mtsat': 'Magnetization transfer saturation',
     't1': 'T1 [ms]',
     }
 

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -173,7 +173,7 @@ metric_to_label = {
     'dti_md': 'Mean diffusivity [$mm^2.s^{-1}$]',
     'dti_rd': 'Radial diffusivity [$mm^2.s^{-1}$]',
     'mtr': 'Magnetization transfer ratio [%]',
-    'mtsat': 'Magnetization transfer saturation',
+    'mtsat': 'Magnetization transfer saturation [%]',
     't1': 'T1 [ms]',
     }
 


### PR DESCRIPTION
This PR fixes two cosmetic issues in figures generated by `sg_generate_figure` script:

- fix superscript in MD and RD ylabel
- change a.u. unit for MTsat to [%]

Fixes #163 