### PR TITLE
generate_figure: small improvements; code clarifications

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -412,9 +412,6 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
             val = [value * scaling_factor.get(metric) for value in val]
             plt.plot([index] * len(val), val, 'r.')
 
-    # Add ManufacturersModelName embedded in each bar
-    ax = label_bar_model(ax, bar_plot, model_sorted)
-
     # Deal with xticklabels
     # Rotate xticklabels at 45deg, align at end
     plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
@@ -433,6 +430,10 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
     # plt.ylim(ylim[contrast])
     # plt.yticks(np.arange(ylim[contrast][0], ylim[contrast][1], step=ystep[contrast]))
     plt.ylabel(metric_to_label[metric], fontsize=15)
+    ax.set_ylim(0.3 * mean_sorted.max(), 1.1 * mean_sorted.max())
+
+    # Add ManufacturersModelName embedded in each bar
+    ax = label_bar_model(ax, bar_plot, model_sorted)
 
     # Add stats per vendor
     x_init_vendor = 0
@@ -596,9 +597,8 @@ def label_bar_model(ax, bar_plot, model_lst):
     :param bar_plot Matplotlib object
     :param model_lst sorted list of model names
     """
-    height = bar_plot[0].get_height()  # in order to align all the labels along y-axis
     for idx, rect in enumerate(bar_plot):
-        ax.text(rect.get_x() + rect.get_width() / 2., 0.1 * height,
+        ax.text(rect.get_x() + rect.get_width() / 2., ax.get_ylim()[0] * 1.1,
                 model_lst[idx], color='white', weight='bold',
                 ha='center', va='bottom', rotation=90)
     return ax

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -281,7 +281,7 @@ def add_flag(coord, name, ax):
     im = OffsetImage(img_rot.clip(0, 1), zoom=0.18)
     im.image.axes = ax
 
-    ab = AnnotationBbox(im, (coord, 0), frameon=False, pad=0, xycoords='data')
+    ab = AnnotationBbox(im, (coord, ax.get_ylim()[0]), frameon=False, pad=0, xycoords='data')
 
     ax.add_artist(ab)
     return ax
@@ -393,7 +393,8 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
         :param model_lst sorted list of model names
         """
         for idx, rect in enumerate(bar_plot):
-            ax.text(rect.get_x() + rect.get_width() / 2., ax.get_ylim()[0] * 1.1,
+            ax.text(rect.get_x() + rect.get_width() / 2.,
+                    ax.get_ylim()[0] * 1.2,
                     model_lst[idx], color='white', weight='bold',
                     ha='center', va='bottom', rotation=90)
         return ax
@@ -441,6 +442,12 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
     # Add space after the site name to allow space for flag
     ax.set_xticklabels([s for s in site_sorted])
     ax.tick_params(labelsize=15)
+
+    # plt.ylim(ylim[contrast])
+    # plt.yticks(np.arange(ylim[contrast][0], ylim[contrast][1], step=ystep[contrast]))
+    plt.ylabel(metric_to_label[metric], fontsize=15)
+    ax.set_ylim(0.3 * mean_sorted.max(), 1.1 * mean_sorted.max())
+
     # Add country flag of each site
     for i, c in enumerate(site_sorted):
         try:
@@ -448,11 +455,6 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
         except KeyError:
             logger.error('ERROR: Flag {} is not defined in dict flags'.format(c))
             sys.exit(1)
-
-    # plt.ylim(ylim[contrast])
-    # plt.yticks(np.arange(ylim[contrast][0], ylim[contrast][1], step=ystep[contrast]))
-    plt.ylabel(metric_to_label[metric], fontsize=15)
-    ax.set_ylim(0.3 * mean_sorted.max(), 1.1 * mean_sorted.max())
 
     # Add ManufacturersModelName embedded in each bar
     ax = label_bar_model(ax, bar_plot, model_sorted)

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -418,7 +418,8 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
     list_colors = [vendor_to_color[i] for i in vendor_sorted]
 
     # Create figure and plot bar graph
-    fig, ax = plt.subplots(figsize=(15, 8))
+    # The horizontal size of the figure is proportional to the number of sites
+    fig, ax = plt.subplots(figsize=(len(site_sorted) * 0.4, 8))
     plt.grid(axis='y')
     ax.set_axisbelow(True)
     bar_plot = plt.bar(range(len(site_sorted)), height=mean_sorted, width=0.5,

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -298,8 +298,13 @@ def add_stats_per_vendor(ax, x_i, x_j, y_max, mean, std, cov_intra, cov_inter, f
     :param color
     """
     # add stats as strings
-    txt = "{0:.2f} $\pm$ {1:.2f}\nCOV intra:{2:.2f}%, inter:{3:.2f}%". \
-        format(mean * f, std * f, cov_intra * 100., cov_inter * 100.)
+    if cov_intra == 0:
+        txt = "{0:.2f} $\pm$ {1:.2f}\nCOV inter:{2:.2f}%". \
+            format(mean * f, std * f, cov_inter * 100.)
+    else:
+        txt = "{0:.2f} $\pm$ {1:.2f}\nCOV intra:{2:.2f}%, inter:{3:.2f}%". \
+            format(mean * f, std * f, cov_intra * 100., cov_inter * 100.)
+
     ax.annotate(txt, xy=(np.mean([x_i, x_j]), y_max), va='center', ha='center',
                 bbox=dict(edgecolor='none', fc=color, alpha=0.3))
     # add rectangle for variance

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -203,6 +203,10 @@ def get_parser():
                 - sub-geneva02\n
             """)
     )
+    parser.add_argument(
+        '-v',
+        action='store_true',
+        help="Increase verbosity; interactive figure.")
     return parser
 
 
@@ -372,7 +376,7 @@ def fetch_subject(filename):
 
 
 def generate_figure_metric(df, metric, stats, display_individual_subjects):
-    if logger.level == 10:
+    if logger.level == logging._nameToLevel['DEBUG']:
         import matplotlib
         matplotlib.use('TkAgg')
         plt.ion()
@@ -645,6 +649,8 @@ def main():
 
     parser = get_parser()
     args = parser.parse_args()
+    if args.v:
+        logger.setLevel(logging.DEBUG)
 
     display_individual_subjects = args.indiv_subj
 

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -376,6 +376,28 @@ def fetch_subject(filename):
 
 
 def generate_figure_metric(df, metric, stats, display_individual_subjects):
+    """
+    Generate bar plot across sites
+    :param df:
+    :param metric:
+    :param stats:
+    :param display_individual_subjects:
+    :return:
+    """
+
+    def label_bar_model(ax, bar_plot, model_lst):
+        """
+        Add ManufacturersModelName embedded in each bar.
+        :param ax Matplotlib axes
+        :param bar_plot Matplotlib object
+        :param model_lst sorted list of model names
+        """
+        for idx, rect in enumerate(bar_plot):
+            ax.text(rect.get_x() + rect.get_width() / 2., ax.get_ylim()[0] * 1.1,
+                    model_lst[idx], color='white', weight='bold',
+                    ha='center', va='bottom', rotation=90)
+        return ax
+
     if logger.level == logging._nameToLevel['DEBUG']:
         import matplotlib
         matplotlib.use('TkAgg')
@@ -462,6 +484,13 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
 
 
 def generate_figure_t1_t2(df, csa_t1, csa_t2):
+    """
+    Generate CSA_T1w vs. CSA_T2w
+    :param df:
+    :param csa_t1:
+    :param csa_t2:
+    :return:
+    """
 
     # Sort values per vendor
     site_sorted = df.sort_values(by=['vendor', 'model', 'site']).index.values
@@ -588,20 +617,6 @@ def get_env(file_param):
             # add to dictionary
             env[newStr.split('=')[0]] = newStr.split('=')[1]
     return env
-
-
-def label_bar_model(ax, bar_plot, model_lst):
-    """
-    Add ManufacturersModelName embedded in each bar.
-    :param ax Matplotlib axes
-    :param bar_plot Matplotlib object
-    :param model_lst sorted list of model names
-    """
-    for idx, rect in enumerate(bar_plot):
-        ax.text(rect.get_x() + rect.get_width() / 2., ax.get_ylim()[0] * 1.1,
-                model_lst[idx], color='white', weight='bold',
-                ha='center', va='bottom', rotation=90)
-    return ax
 
 
 def remove_subject(subject, metric, dict_exclude_subj):

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -457,6 +457,12 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
     # Add ManufacturersModelName embedded in each bar
     ax = label_bar_model(ax, bar_plot, model_sorted)
 
+    # Add a red cross for sites not considered in the statistics
+    for idx, rect in enumerate(bar_plot):
+        if df['exclude'][site_sorted[idx]]:
+            ax.text(rect.get_x() + rect.get_width() / 2., rect._height, 'x', color='red', weight='bold', ha='center',
+                    va='center', size=20)
+
     # Add stats per vendor
     x_init_vendor = 0
     # height_bar = [rect.get_height() for idx,rect in enumerate(bar_plot)]

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -260,33 +260,6 @@ def aggregate_per_site(dict_results, metric, dict_exclude_subj):
     return results_agg
 
 
-def add_flag(coord, name, ax):
-    """
-    Add flag images to the plot.
-    :param coord Coordinate of the xtick
-    :param name Name of the country
-    :param ax Matplotlib ax
-    """
-
-    def _get_flag(name):
-        """
-        Get the flag of a country from the folder flags.
-        :param name Name of the country
-        """
-        with importlib.resources.path(spinegeneric.flags, f'{name}.png') as path_flag:
-            return plt.imread(path_flag.__str__())
-
-    img = _get_flag(name)
-    img_rot = ndimage.rotate(img, 45)
-    im = OffsetImage(img_rot.clip(0, 1), zoom=0.18)
-    im.image.axes = ax
-
-    ab = AnnotationBbox(im, (coord, ax.get_ylim()[0]), frameon=False, pad=0, xycoords='data')
-
-    ax.add_artist(ab)
-    return ax
-
-
 def add_stats_per_vendor(ax, x_i, x_j, y_max, mean, std, cov_intra, cov_inter, f, color):
     """"
     Add stats per vendor to the plot.
@@ -384,6 +357,32 @@ def generate_figure_metric(df, metric, stats, display_individual_subjects):
     :param display_individual_subjects:
     :return:
     """
+
+    def add_flag(coord, name, ax):
+        """
+        Add flag images to the plot.
+        :param coord Coordinate of the xtick
+        :param name Name of the country
+        :param ax Matplotlib ax
+        """
+
+        def _get_flag(name):
+            """
+            Get the flag of a country from the folder flags.
+            :param name Name of the country
+            """
+            with importlib.resources.path(spinegeneric.flags, f'{name}.png') as path_flag:
+                return plt.imread(path_flag.__str__())
+
+        img = _get_flag(name)
+        img_rot = ndimage.rotate(img, 45)
+        im = OffsetImage(img_rot.clip(0, 1), zoom=0.18)
+        im.image.axes = ax
+
+        ab = AnnotationBbox(im, (coord, ax.get_ylim()[0]), frameon=False, pad=0, xycoords='data')
+
+        ax.add_artist(ab)
+        return ax
 
     def label_bar_model(ax, bar_plot, model_lst):
         """


### PR DESCRIPTION
This PR includes the following improvements:
- Exclude outlier sites from cov_intra computation. Fixes #178
- Do not display COV_intra for single-subject case. Fixes #180
- Display red cross if site is excluded from statistics.
- Adjust figure size horizontally based on number of sites.
- Adjust ylim, improved dynamic (ylim[0] is no more 0)
- Refactoring to nest functions and simplify code.

TODO:
- change flag: `-indiv-subj` --> `-indiv-sub` and document 