### PR TITLE
Clarify output display for params checker

### DIFF
--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -69,19 +69,19 @@ def main():
                     keys_contrast = data[Manufacturer][ManufacturersModelName][str(Contrast)].keys()
                     if 'RepetitionTime' in keys_contrast:
                         if (RepetitionTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]) > 0.1:
-                            logging.warning(' Incorrect RepetitionTime: ' + item.filename + '; TR=' + str(RepetitionTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]))
+                            logging.warning(' ' + item.filename + ': Incorrect RepetitionTime: TR=' + str(RepetitionTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]))
                     EchoTime=item.get_metadata()['EchoTime']
                     if 'EchoTime' in keys_contrast:
                         if (EchoTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]) > 0.1:
-                            logging.warning(' Incorrect EchoTime: ' + item.filename + '; TE=' + str(EchoTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]))
+                            logging.warning(' ' + item.filename + ': Incorrect EchoTime: TE=' + str(EchoTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]))
                     FlipAngle=item.get_metadata()['FlipAngle']
                     if 'FlipAngle' in keys_contrast:
                         if data[Manufacturer][ManufacturersModelName][str(Contrast)]["FlipAngle"] != FlipAngle:
-                            logging.warning(' Incorrect FlipAngle: ' + item.filename + '; FA=' + str(FlipAngle) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["FlipAngle"])) 
+                            logging.warning(' ' + item.filename + ': Incorrect FlipAngle: FA=' + str(FlipAngle) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["FlipAngle"])) 
                 else:
-                    logging.warning(item.filename + ' Missing: '+ ManufacturersModelName + '; Cannot check parameters.')
+                    logging.warning(' ' + item.filename + ': Missing: '+ ManufacturersModelName + '; Cannot check parameters.')
         else:
-            logging.warning(item.filename + ' Missing Manufacturer in json sidecar; Cannot check parameters.')
+            logging.warning(' ' + item.filename + ': Missing Manufacturer in json sidecar; Cannot check parameters.')
 
     #Print WARNING log
     if path_warning_log:


### PR DESCRIPTION
Fixes #191 

Output example from single-subject:
```
(base) alfoi@MacBook-Pro:data-single-subject % sg_params_checker -path-in .
/Users/alfoi/miniconda3/lib/python3.7/site-packages/bids/layout/models.py:102: FutureWarning: The 'extension' entity currently excludes the leading dot ('.'). As of version 0.14.0, it will include the leading dot. To suppress this warning and include the leading dot, use `bids.config.set_option('extension_initial_dot', True)`.
  FutureWarning)
WARNING: sub-douglas_T2w.nii.gz: Incorrect FlipAngle: FA=120 instead of 180
WARNING: sub-mgh_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-tokyoSigna1_T2star.nii.gz: Incorrect FlipAngle: FA=20 instead of 30
WARNING: sub-tokyoSigna2_T2star.nii.gz: Incorrect FlipAngle: FA=20 instead of 30
WARNING: sub-ucl_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
```

Output example from multi-subject:
```
(base) alfoi@MacBook-Pro:data-multi-subject % sg_params_checker -path-in .
/Users/alfoi/miniconda3/lib/python3.7/site-packages/bids/layout/models.py:102: FutureWarning: The 'extension' entity currently excludes the leading dot ('.'). As of version 0.14.0, it will include the leading dot. To suppress this warning and include the leading dot, use `bids.config.set_option('extension_initial_dot', True)`.
  FutureWarning)
WARNING: sub-amu01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-amu01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-amu02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-amu02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-amu03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-amu03_T2w.nii.gz: Incorrect FlipAngle: FA=135 instead of 120
WARNING: sub-amu04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-amu04_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-amu05_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-amu05_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-beijingVerio01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-beijingVerio01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-beijingVerio02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-beijingVerio02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-beijingVerio03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-beijingVerio03_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-beijingVerio04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-beijingVerio04_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-nottwil01_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-strasbourg01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-strasbourg01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-strasbourg02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-strasbourg02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120
WARNING: sub-ucl01_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T1w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T2star.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T2w.nii.gz: Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: sub-vallHebron01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron01_T2w.nii.gz: Incorrect FlipAngle: FA=170 instead of 180
WARNING: sub-vallHebron02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron04_T2w.nii.gz: Incorrect FlipAngle: FA=165 instead of 180
WARNING: sub-vallHebron05_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron06_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron07_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5
WARNING: sub-vallHebron07_T2w.nii.gz: Incorrect FlipAngle: FA=150 instead of 180
```

To test:
```
git checkout af/191-change-output-checker
pip install -e .
```