### PR TITLE
Parameters checker now sets tolerance on the absolute (unsigned) difference

### DIFF
--- a/docs/data-acquisition.rst
+++ b/docs/data-acquisition.rst
@@ -189,6 +189,8 @@ by the validator. If a parameter does not match, a warning message is triggered.
 This validator is exposed in this command line interface (CLI) function: **sg_params_checker**. This function is run 
 during continuous integration (CI), for each dataset, ensuring valid dataset throughout the life cycle of the project. 
 
+The json file containing the recommended acquisition parameters is located under `/spinegeneric/cli/specs.json`.
+
 Example usage and expected output:
 
 .. code-block:: bash

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -68,11 +68,11 @@ def main():
                     Contrast = ((item.filename).split('_')[-1]).split('.')[0]
                     keys_contrast = data[Manufacturer][ManufacturersModelName][str(Contrast)].keys()
                     if 'RepetitionTime' in keys_contrast:
-                        if (RepetitionTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]) > 0.1:
+                        if abs(RepetitionTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]) > 0.1:
                             logging.warning(' Incorrect RepetitionTime: ' + item.filename + '; TR=' + str(RepetitionTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]))
                     EchoTime=item.get_metadata()['EchoTime']
                     if 'EchoTime' in keys_contrast:
-                        if (EchoTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]) > 0.1:
+                        if abs(EchoTime - data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]) > 0.1:
                             logging.warning(' Incorrect EchoTime: ' + item.filename + '; TE=' + str(EchoTime) + ' instead of ' + str(data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]))
                     FlipAngle=item.get_metadata()['FlipAngle']
                     if 'FlipAngle' in keys_contrast:


### PR DESCRIPTION
Fixes #189 

Output example for single-subject:
```
(base) alfoi@MacBook-Pro:data-single-subject % sg_params_checker -path-in .
/Users/alfoi/miniconda3/lib/python3.7/site-packages/bids/layout/models.py:102: FutureWarning: The 'extension' entity currently excludes the leading dot ('.'). As of version 0.14.0, it will include the leading dot. To suppress this warning and include the leading dot, use `bids.config.set_option('extension_initial_dot', True)`.
  FutureWarning)
WARNING: Incorrect FlipAngle: sub-douglas_T2w.nii.gz; FA=120 instead of 180
WARNING: Incorrect RepetitionTime: sub-mgh_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-tokyoSigna1_T2star.nii.gz; FA=20 instead of 30
WARNING: Incorrect FlipAngle: sub-tokyoSigna2_T2star.nii.gz; FA=20 instead of 30
WARNING:sub-ucl_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
```
Output example for multi-subject:

```
(base) alfoi@MacBook-Pro:data-multi-subject % sg_params_checker -path-in .
/Users/alfoi/miniconda3/lib/python3.7/site-packages/bids/layout/models.py:102: FutureWarning: The 'extension' entity currently excludes the leading dot ('.'). As of version 0.14.0, it will include the leading dot. To suppress this warning and include the leading dot, use `bids.config.set_option('extension_initial_dot', True)`.
  FutureWarning)
WARNING: Incorrect RepetitionTime: sub-amu01_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-amu01_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-amu02_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-amu02_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-amu03_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-amu03_T2w.nii.gz; FA=135 instead of 120
WARNING: Incorrect RepetitionTime: sub-amu04_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-amu04_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-amu05_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-amu05_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-beijingVerio01_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-beijingVerio01_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-beijingVerio02_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-beijingVerio02_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-beijingVerio03_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-beijingVerio03_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-beijingVerio04_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-beijingVerio04_T2w.nii.gz; FA=180 instead of 120
WARNING:sub-nottwil01_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil01_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil01_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil02_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil02_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil02_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil03_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil03_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil03_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil04_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil04_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil04_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil05_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil05_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil05_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil06_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil06_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-nottwil06_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: Incorrect RepetitionTime: sub-strasbourg01_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-strasbourg01_T2w.nii.gz; FA=180 instead of 120
WARNING: Incorrect RepetitionTime: sub-strasbourg02_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-strasbourg02_T2w.nii.gz; FA=180 instead of 120
WARNING:sub-ucl01_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl01_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl01_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl02_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl02_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl02_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl03_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl03_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl03_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl04_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl04_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl04_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl05_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl05_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl05_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl06_T1w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl06_T2star.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING:sub-ucl06_T2w.nii.gz Missing Manufacturer in json sidecar; Cannot check parameters.
WARNING: Incorrect RepetitionTime: sub-vallHebron01_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-vallHebron01_T2w.nii.gz; FA=170 instead of 180
WARNING: Incorrect RepetitionTime: sub-vallHebron02_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect RepetitionTime: sub-vallHebron03_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect RepetitionTime: sub-vallHebron04_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-vallHebron04_T2w.nii.gz; FA=165 instead of 180
WARNING: Incorrect RepetitionTime: sub-vallHebron05_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect RepetitionTime: sub-vallHebron06_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect RepetitionTime: sub-vallHebron07_T2w.nii.gz; TR=2 instead of 1.5
WARNING: Incorrect FlipAngle: sub-vallHebron07_T2w.nii.gz; FA=150 instead of 180
```


To test:
```
git checkout af/189-abs-param-checker
pip install -e .
```