### PR TITLE
Fix different x and y size in t1-t2 agreement figure

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -579,12 +579,14 @@ def generate_figure_t1_t2(dict_exclude_subj):
 
     # Exlude subjects
     subjects_removed = []
-    # Loop across subjects
-    for subject, _ in t1_t2_df.iterrows():
-        # Exclude subject if is listed in csa_t1 or csa_t2 key
-        if subject in dict_exclude_subj['csa_t1'] or subject in dict_exclude_subj['csa_t2']:
-            t1_t2_df.loc[subject, 'exclude'] = True
-            subjects_removed.append(subject)
+    # Check if any subject is listed to exclude
+    if 'csa_t1' in dict_exclude_subj or 'csa_t2' in dict_exclude_subj:
+        # Loop across subjects
+        for subject, _ in t1_t2_df.iterrows():
+            # Exclude subject if is listed in csa_t1 or csa_t2 key
+            if subject in dict_exclude_subj['csa_t1'] or subject in dict_exclude_subj['csa_t2']:
+                t1_t2_df.loc[subject, 'exclude'] = True
+                subjects_removed.append(subject)
     logger.info("Subjects removed: {}".format(subjects_removed))
 
     # Generate figure for T1w and T2w agreement for all vendors together


### PR DESCRIPTION
This PR proposed one of possible fix for https://github.com/spine-generic/spine-generic/issues/193.

For successful creation of t1-t2 agreement figure, it is necessary to x and y-axis have same size (i.e., same number of subjects). This is not satisfied when:
- some subjects are excluded from `csa_t1` but not from `csa_t2` (or vice versa)
- no exclude.yml file is used, but some subjects have in input `csa-SC_T1w.csv` or `csa-SC_T2w.csv` files _None_ values

This PR adds:
- merging of subjects from `csa_t1` and `csa_t2` keys. For example, when input `exclude.yml` file looks like:

```
csa_t1:
- sub-oxfordFmrib04  # this is only example
- sub-mountSinai03  # this is only example
csa_t2:
- sub-beijingPrisma03  # this is only example
```

then, after merging inside script, it looks like:

```
csa_t1:
- sub-oxfordFmrib04  # this is only example
- sub-mountSinai03  # this is only example
- sub-beijingPrisma03  # this is only example
csa_t2:
- sub-oxfordFmrib04  # this is only example
- sub-mountSinai03  # this is only example
- sub-beijingPrisma03  # this is only example
```

i.e. `csa_t1` and `csa_t2` are same.

- error message when no exclude.yml file is used and some subject has _None_ values

**CONS** - with this workaround, subjects listed only in `csa_t1` (or only in `csa_t2`) are excluded not only from t1-t2 agreement figure, but also from `fig_csa_t1.png` and `fig_csa_t2.png` bars figures. It is not ideal, because when subject has only bad `fig_csa_t1.png`, it is not necessary to exclude him also from `fig_csa_t2.png`. But, to ensure this, it would require bigger code refactoring because subjects are excluded for each metric (t1, t2,...) separatelly and grouped by sites (so, sub_ID is lost and only lists of values for sites are further processed).

Fixes: https://github.com/spine-generic/spine-generic/issues/193