### PR TITLE
Fix different x and y size in t1-t2 agreement figure

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -562,13 +562,12 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
     CSA_dict = defaultdict(list)
     # loop across sites
     for index, line in enumerate(csa_t1):
+        vendor = line[1]
         # Loop across subjects, making sure to only populate the dictionary with subjects existing both for T1 and T2
         for subject in csa_t1[index][4]:
             if subject in csa_t2[index, 4]:
-                # line[1] denotes vendor
-                # TODO: explicit with variable vendor
-                CSA_dict[line[1] + '_t1'].append(csa_t1[index, 3][csa_t1[index, 4].index(subject)])
-                CSA_dict[line[1] + '_t2'].append(csa_t2[index, 3][csa_t2[index, 4].index(subject)])
+                CSA_dict[vendor + '_t1'].append(csa_t1[index, 3][csa_t1[index, 4].index(subject)])
+                CSA_dict[vendor + '_t2'].append(csa_t2[index, 3][csa_t2[index, 4].index(subject)])
 
     # Generate figure for T1w and T2w agreement for all vendors together
     fig, ax = plt.subplots(figsize=(7, 7))
@@ -782,7 +781,7 @@ def main():
         df, stats = compute_statistics(df)
 
         # Generate figure
-        # generate_figure_metric(df, metric, stats, display_individual_subjects, show_ci=args.show_ci)
+        generate_figure_metric(df, metric, stats, display_individual_subjects, show_ci=args.show_ci)
 
         # Get T1w and T2w CSA (will be used later for another figure)
         if metric == "csa_t1":

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -256,10 +256,12 @@ def aggregate_per_site(dict_results, metric, dict_exclude_subj):
                 results_agg[site]['vendor'] = participants['manufacturer'][rowIndex].array[0]
                 results_agg[site]['model'] = participants['manufacturers_model_name'][rowIndex].array[0]
                 results_agg[site]['val'] = []
+                results_agg[site]['subject'] = []
             # add val for site (ignore None)
             val = dict_results[i][metric_field]
             if not val == 'None':
                 results_agg[site]['val'].append(float(val))
+                results_agg[site]['subject'].append(subject)
         else:
             subjects_removed.append(subject)
     logger.info("Subjects removed: {}".format(subjects_removed))
@@ -779,7 +781,7 @@ def main():
         df, stats = compute_statistics(df)
 
         # Generate figure
-        generate_figure_metric(df, metric, stats, display_individual_subjects, show_ci=args.show_ci)
+        # generate_figure_metric(df, metric, stats, display_individual_subjects, show_ci=args.show_ci)
 
         # Get T1w and T2w CSA (will be used later for another figure)
         if metric == "csa_t1":

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -533,6 +533,26 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
     :param csa_t2:
     :return:
     """
+    def compute_regression(x, y):
+        """
+        Compute linear regression between x and y:
+        y = Slope * x + Intercept
+
+        :param x: list:
+        :param y: list:
+        :return: results of linear regression
+        """
+        # create object for the class
+        linear_regression = LinearRegression()
+        # perform linear regression (compute slope and intercept)
+        linear_regression.fit(x.reshape(-1, 1), y.reshape(-1, 1))
+        intercept = linear_regression.intercept_
+        slope = linear_regression.coef_
+        # compute prediction
+        reg_predictor = linear_regression.predict(x)
+        # compute coefficient of determination R^2 of the prediction
+        r2_sc = linear_regression.score(x, y)
+        return intercept, slope, reg_predictor, r2_sc
 
     # Sort values per vendor
     site_sorted = df.sort_values(by=['vendor', 'model', 'site']).index.values
@@ -681,28 +701,6 @@ def remove_subject(subject, metric, dict_exclude_subj):
         if subject in dict_exclude_subj[metric]:
             return True
     return False
-
-
-def compute_regression(x, y):
-    """
-    Compute linear regression between x and y:
-    y = Slope * x + Intercept
-
-    :param x: list:
-    :param y: list:
-    :return: results of linear regression
-    """
-    # create object for the class
-    linear_regression = LinearRegression()
-    # perform linear regression (compute slope and intercept)
-    linear_regression.fit(x.reshape(-1, 1), y.reshape(-1, 1))
-    intercept = linear_regression.intercept_
-    slope = linear_regression.coef_
-    # compute prediction
-    reg_predictor = linear_regression.predict(x)
-    # compute coefficient of determination R^2 of the prediction
-    r2_sc = linear_regression.score(x, y)
-    return intercept, slope, reg_predictor, r2_sc
 
 
 def main():

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -615,7 +615,9 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
         # Enforce square grid
         plt.gca().set_aspect('equal', adjustable='box')
         # Compute linear fit
-        intercept, slope, reg_predictor, r2_sc = compute_regression(CSA_dict, vendor)
+        intercept, slope, reg_predictor, r2_sc = \
+            compute_regression(np.array(CSA_dict[vendor + '_t2']).reshape(-1, 1),
+                               np.array(CSA_dict[vendor + '_t1']).reshape(-1, 1))
         # Place regression equation to upper-left corner
         plt.text(0.1, 0.9,
                  "y = {0:.4}x + {1:.4}\nR\u00b2 = {2:.4}".format(float(slope), float(intercept), float(r2_sc)),
@@ -681,31 +683,25 @@ def remove_subject(subject, metric, dict_exclude_subj):
     return False
 
 
-def compute_regression(CSA_dict, vendor):
-    # TODO: refactor to make it lower level (ie no need to deal with dict and vendor)
+def compute_regression(x, y):
     """
-    Compute linear regression for T1w and T2 CSA agreement
-    :param CSA_dict: dict with T1w and T2w CSA values
-    :param vendor: vendor name
+    Compute linear regression between x and y:
+    y = Slope * x + Intercept
+
+    :param x: list:
+    :param y: list:
     :return: results of linear regression
     """
-    # Y = Slope*X + Intercept
-
     # create object for the class
     linear_regression = LinearRegression()
     # perform linear regression (compute slope and intercept)
-    linear_regression.fit(np.concatenate(CSA_dict[vendor + '_t2'], axis=0).reshape(-1, 1),
-                          np.concatenate(CSA_dict[vendor + '_t1'], axis=0).reshape(-1, 1))
+    linear_regression.fit(x.reshape(-1, 1), y.reshape(-1, 1))
     intercept = linear_regression.intercept_
     slope = linear_regression.coef_
-
     # compute prediction
-    reg_predictor = linear_regression.predict(
-        np.concatenate(CSA_dict[vendor + '_t2'], axis=0).reshape(-1, 1))
+    reg_predictor = linear_regression.predict(x)
     # compute coefficient of determination R^2 of the prediction
-    r2_sc = linear_regression.score(np.concatenate(CSA_dict[vendor + '_t2'], axis=0).reshape(-1, 1),
-                          np.concatenate(CSA_dict[vendor + '_t1'], axis=0).reshape(-1, 1))
-
+    r2_sc = linear_regression.score(x, y)
     return intercept, slope, reg_predictor, r2_sc
 
 


### PR DESCRIPTION
Fixes #193 by adding a vector of subject in the dataframe, enabling to check potential mismatch in `generate_figure_t1_t2`.

Also clarified code of `compute_regression()` by moving higher level stuff (dict, vendor info) to the caller.

Alternative approach to https://github.com/spine-generic/spine-generic/pull/199