### PR TITLE
Automatize text generation based on results

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -381,9 +381,9 @@ def output_text(stats, metric):
     :param metric: currently processed metric (e.g, dti_fa,...)
     """
 
-    def check_p_value(p_val):
+    def format_p_value(p_val):
         """
-        Check if p-value is lower than 0.01, if so, change it to "<0.01", otherwise, round it to two decimals
+        If p-value is lower than 0.01, change it to "<0.01", otherwise, round it to two decimals
         :param p_val: input p-value
         :return: p_val: processed p-value (replaced by "<0.01" or rounded to two decimals)
         """
@@ -392,7 +392,7 @@ def output_text(stats, metric):
         else:
             p_val = round(p_val, 2)
 
-        return p_val
+        return str(p_val)
 
     fname = os.path.join(os.path.abspath(os.curdir), "statistical_results.txt")
     # Check if file exist, if not create it, if so, append to this file
@@ -412,7 +412,7 @@ def output_text(stats, metric):
     for count, vendor in enumerate(stats['cov_inter'].keys()):
         cov_inter = stats['cov_inter'][vendor] * 100
         p_val = stats['anova_site'][vendor][1]
-        p_val = check_p_value(p_val)
+        p_val = format_p_value(p_val)
         file.write("{:.1f}% (p={}) for {}".format(cov_inter, p_val, vendor))
         if count == 0:
             file.write(", ")
@@ -424,7 +424,7 @@ def output_text(stats, metric):
     p_val_anova = stats['anova_vendor'][1]
     # Write post-hoc Tukey results if inter-vendor difference was significant
     if p_val_anova < 0.05:
-        p_val_anova = check_p_value(p_val_anova)
+        p_val_anova = format_p_value(p_val_anova)
         file.write("The inter-vendor difference was significant (p={}), with the Tukey test showing significant "
                     "differences ".format(p_val_anova))
 
@@ -437,7 +437,7 @@ def output_text(stats, metric):
                 vendor1 = stats['tukey_test']._results_table[counter][0].data   # 1st vendor
                 vendor2 = stats['tukey_test']._results_table[counter][1].data   # 2nd vendor
                 p_adj = stats['tukey_test']._results_table[counter][3].data     # adjusted p-val
-                p_adj = check_p_value(p_adj)
+                p_adj = format_p_value(p_adj)
                 file.write('between {} and {} (p-adj={})'.format(vendor1, vendor2, p_adj))
                 index -= 1
                 # Decide which conjunction will be used
@@ -447,7 +447,7 @@ def output_text(stats, metric):
                     file.write(' and ')
     # Inter-vendor difference was not significant
     else:
-        p_val_anova = check_p_value(p_val_anova)
+        p_val_anova = format_p_value(p_val_anova)
         file.write("The inter-vendor difference was not significant (p={})".format(p_val_anova))
 
     # add two blank lines between individual metrics

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -384,15 +384,15 @@ def output_text(stats, metric):
     def format_p_value(p_val):
         """
         If p-value is lower than 0.01, change it to "<0.01", otherwise, round it to two decimals
-        :param p_val: input p-value
-        :return: p_val: processed p-value (replaced by "<0.01" or rounded to two decimals)
+        :param p_val: input p-value as a float
+        :return: p_val: processed p-value (replaced by "<0.01" or rounded to two decimals) as a str
         """
         if p_val < 0.01:
             p_val = "<0.01"
         else:
-            p_val = round(p_val, 2)
+            p_val = '=' + str(round(p_val, 2))
 
-        return str(p_val)
+        return p_val
 
     fname = os.path.join(os.path.abspath(os.curdir), "statistical_results.txt")
     # Check if file exist, if not create it, if so, append to this file
@@ -413,7 +413,7 @@ def output_text(stats, metric):
         cov_inter = stats['cov_inter'][vendor] * 100
         p_val = stats['anova_site'][vendor][1]
         p_val = format_p_value(p_val)
-        file.write("{:.1f}% (p={}) for {}".format(cov_inter, p_val, vendor))
+        file.write("{:.1f}% (p{}) for {}".format(cov_inter, p_val, vendor))
         if count == 0:
             file.write(", ")
         elif count == 1:
@@ -425,7 +425,7 @@ def output_text(stats, metric):
     # Write post-hoc Tukey results if inter-vendor difference was significant
     if p_val_anova < 0.05:
         p_val_anova = format_p_value(p_val_anova)
-        file.write("The inter-vendor difference was significant (p={}), with the Tukey test showing significant "
+        file.write("The inter-vendor difference was significant (p{}), with the Tukey test showing significant "
                     "differences ".format(p_val_anova))
 
         # Get significant post-hoc results
@@ -438,7 +438,7 @@ def output_text(stats, metric):
                 vendor2 = stats['tukey_test']._results_table[counter][1].data   # 2nd vendor
                 p_adj = stats['tukey_test']._results_table[counter][3].data     # adjusted p-val
                 p_adj = format_p_value(p_adj)
-                file.write('between {} and {} (p-adj={})'.format(vendor1, vendor2, p_adj))
+                file.write('between {} and {} (p-adj{})'.format(vendor1, vendor2, p_adj))
                 index -= 1
                 # Decide which conjunction will be used
                 if index == 2:
@@ -448,7 +448,7 @@ def output_text(stats, metric):
     # Inter-vendor difference was not significant
     else:
         p_val_anova = format_p_value(p_val_anova)
-        file.write("The inter-vendor difference was not significant (p={})".format(p_val_anova))
+        file.write("The inter-vendor difference was not significant (p{})".format(p_val_anova))
 
     # add dot to the end of previous sentence and two blank lines between individual metrics
     file.write('.\n\n')

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -194,7 +194,7 @@ def get_parser():
         '-output-text',
         required=False,
         action='store_true',
-        help="Write statistics results into text file.")
+        help="Write statistical results into text file.")
     parser.add_argument(
         '-exclude',
         required=False,
@@ -869,7 +869,7 @@ def main():
         df, stats = compute_statistics(df)
 
         # Write statistical results into text file
-        if args.output_text == True:
+        if args.output_text:
             output_text(stats, metric)
 
         # Generate figure

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -376,7 +376,7 @@ def compute_statistics(df):
 
 def output_text(stats, metric):
     """
-    # Write statistical results into text file
+    # Embed statistical results into sentences so they can easily be copy/pasted into a manuscript. 
     :param stats: dict with stat resutls
     :param metric: currently processed metric (e.g, dti_fa,...)
     """

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -405,7 +405,7 @@ def output_text(stats, metric):
     file.write('{}:\n\n'.format(metric))
     # Find and write highest intra-site COV (rounded up)
     file.write("The intra-site coefficients of variation (COVs) were averaged for each vendor and found to be all "
-                "just under {}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100)))
+                "under {}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100)))
 
     # Write inter-site COVs and ANOVA p-values
     file.write("The inter-site COVs (and inter-site ANOVA p-values) were ")
@@ -450,7 +450,7 @@ def output_text(stats, metric):
         p_val_anova = format_p_value(p_val_anova)
         file.write("The inter-vendor difference was not significant (p={})".format(p_val_anova))
 
-    # add two blank lines between individual metrics
+    # add dot to the end of previous sentence and two blank lines between individual metrics
     file.write('.\n\n')
     file.close()
 


### PR DESCRIPTION
This PR automatizes text generation based on results.
The feature is activated with the flag `-output-text`, then the `main` calls a function `output_text()` which performs writing of results into `statistical_results.txt` file.
P-values are rounded to two decimals, if p<0.01 (e.g. 0.003), it is replace by str "<0.01".

The output `statistical_results.txt` looks like:
<img width="924" alt="Snímek obrazovky 2020-09-12 v 20 46 45" src="https://user-images.githubusercontent.com/39456460/93002717-33401480-f539-11ea-869d-d72c302b288f.png">


Fixes: https://github.com/spine-generic/spine-generic/issues/204