### PR TITLE
Cosmetic improvements with formatted output of statistics

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -396,18 +396,31 @@ def output_text(stats):
 
     txt = ""
 
-    # Write metric name and two blank lines
+    # Find out if this is single-subject data (single value per site)
+    if max(stats['cov_intra'].values()) == 0.0:
+        single_subject = True
+    else:
+        single_subject = False
+
     # Find and write highest intra-site COV (rounded up)
-    txt += "The intra-site coefficients of variation (COVs) were averaged for each vendor and found to be all under " \
-           "{}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100))
+    if not single_subject:
+        txt += "The intra-site coefficients of variation (COVs) were averaged for each vendor and found to be all under " \
+               "{}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100))
 
     # Write inter-site COVs and ANOVA p-values
-    txt += "The inter-site COVs (and inter-site ANOVA p-values) were "
+    if single_subject:
+        txt += "The inter-site COVs were "
+    else:
+        txt += "The inter-site COVs (and inter-site ANOVA p-values) were "
+
     for count, vendor in enumerate(stats['cov_inter'].keys()):
         cov_inter = stats['cov_inter'][vendor] * 100
         p_val = stats['anova_site'][vendor][1]
         p_val = format_p_value(p_val)
-        txt += "{:.1f}% (p{}) for {}".format(cov_inter, p_val, vendor)
+        if single_subject:
+            txt += "{:.1f}% for {}".format(cov_inter, vendor)
+        else:
+            txt += "{:.1f}% (p{}) for {}".format(cov_inter, p_val, vendor)
         if count == 0:
             txt += ", "
         elif count == 1:
@@ -444,7 +457,7 @@ def output_text(stats):
         p_val_anova = format_p_value(p_val_anova)
         txt += "The inter-vendor difference was not significant (p{})".format(p_val_anova)
 
-    # add dot to the end of previous sentence and two blank lines between individual metrics
+    txt += "."
     logger.info(txt)
 
 

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -445,7 +445,6 @@ def output_text(stats):
         txt += "The inter-vendor difference was not significant (p{})".format(p_val_anova)
 
     # add dot to the end of previous sentence and two blank lines between individual metrics
-    txt += ".\n\n"
     logger.info(txt)
 
 
@@ -832,7 +831,7 @@ def main():
             continue
 
         # Open CSV file and create dict
-        logger.info('\nProcessing: ' + csv_file)
+        logger.info("\n{}\n====================================================".format(csv_file))
         dict_results = []
         with open(csv_file, newline='') as f_csv:
             reader = csv.DictReader(f_csv)

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -404,7 +404,7 @@ def output_text(stats):
 
     # Find and write highest intra-site COV (rounded up)
     if not single_subject:
-        txt += "The intra-site coefficients of variation (COVs) were averaged for each vendor and found to be all under " \
+        txt += "The intra-site COVs were averaged for each vendor and found to be all under " \
                "{}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100))
 
     # Write inter-site COVs and ANOVA p-values

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -174,8 +174,8 @@ LABELSIZE = 15
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Generate figures for the spine-generic project. "
-                    "The following metrics will be computed:\n {}".format(list(metric_to_field.keys())),
+        description="Generate figures for the spine-generic project. Statistical resuls are output in the file '{}'. "
+                    "The following metrics will be computed:\n {}".format(FNAME_LOG, list(metric_to_field.keys())),
         formatter_class=sg.utils.SmartFormatter,
     )
     parser.add_argument(
@@ -196,7 +196,7 @@ def get_parser():
         '-output-text',
         required=False,
         action='store_true',
-        help="Write statistical results into text file.")
+        help="Write statistical results into text file: '{}'.".format(FNAME_TEXT))
     parser.add_argument(
         '-exclude',
         required=False,

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -823,9 +823,6 @@ def main():
             os.chdir(args.path_results)
         else:
             raise FileNotFoundError("Directory '{}' was not found.".format(args.path_results))
-    else:
-        # Stay in current directory (assume it is results directory)
-        os.chdir(os.getcwd())
 
     # Dump log file there
     fh = logging.FileHandler(os.path.join(os.path.abspath(os.curdir), 'log_stats.txt'))

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -13,7 +13,6 @@ import argparse
 import importlib.resources
 import tqdm
 import sys
-import glob
 import csv
 import pandas as pd
 import subprocess
@@ -43,6 +42,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)  # default: logging.DEBUG, logging.INFO
 hdlr = logging.StreamHandler(sys.stdout)
 logging.root.addHandler(hdlr)
+
+FNAME_LOG = 'log_stats.txt'
+FNAME_TEXT = 'statistical_results.txt'
 
 # country dictionary: key: site, value: country name
 # Flags are downloaded from: https://emojipedia.org/
@@ -394,12 +396,7 @@ def output_text(stats, metric):
 
         return p_val
 
-    fname = os.path.join(os.path.abspath(os.curdir), "statistical_results.txt")
-    # Check if file exist, if not create it, if so, append to this file
-    if not os.path.isfile(fname):
-        file = open(fname, "w+")
-    else:
-        file = open(fname, "a+")
+    file = open(FNAME_TEXT, "a+")
 
     # Write metric name and two blank lines
     file.write('{}:\n\n'.format(metric))
@@ -454,7 +451,6 @@ def output_text(stats, metric):
     file.write('.\n\n')
     file.close()
 
-    return None
 
 def fetch_subject(filename):
     """
@@ -825,10 +821,17 @@ def main():
             raise FileNotFoundError("Directory '{}' was not found.".format(args.path_results))
 
     # Dump log file there
-    fh = logging.FileHandler(os.path.join(os.path.abspath(os.curdir), 'log_stats.txt'))
+    if os.path.exists(FNAME_LOG):
+        os.remove(FNAME_LOG)
+    fh = logging.FileHandler(os.path.join(os.path.abspath(os.curdir), FNAME_LOG))
     logging.root.addHandler(fh)
 
-    # loop across results (individual *.csv files) and generate figures and compute statistics
+    # If asking to output formatted text, remove existing file to prevent appending
+    if os.path.exists(FNAME_TEXT):
+        os.remove(FNAME_TEXT)
+
+
+    # loop across individual *.csv files and generate figures and compute statistics
     for csv_file in file_to_metric.keys():
 
         # skip metric, if *.csv file does not exist


### PR DESCRIPTION
This PR brings few improvements for the formatting of statistics output:
- Skip intra-site ANOVAs and pvalues if single-subject
- Remove the blurb about the intra-site COV if it is equal to 0 (ie: single-subject case).
- Removed COVs acronym definition
- Remove existing output txt file
- Output formatted statistics into the same log_stats.txt file

Fixes #214 