### PR TITLE
Round intra-site COV to first decimal for output statistics text.

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -405,7 +405,7 @@ def output_text(stats):
     # Find and write highest intra-site COV (rounded up)
     if not single_subject:
         txt += "The intra-site COVs were averaged for each vendor and found to be all under " \
-               "{}%. ".format(math.ceil(max(stats['cov_intra'].values()) * 100))
+               "{:.1f}%. ".format(math.ceil(max(stats['cov_intra'].values())*1000)/10)
 
     # Write inter-site COVs and ANOVA p-values
     if single_subject:


### PR DESCRIPTION
Round intra-site COV to the first decimal instead of using int in -output-text outputs.

before this PR:
`The intra-site COVs were averaged for each vendor and found to be all under 8%.`

with this PR:
`The intra-site COVs were averaged for each vendor and found to be all under 7.8%.`

( Values themself in this particular case are: )
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/39456460/93504345-a7076600-f919-11ea-9985-c90a1fb0e929.png">


Fixes: https://github.com/spine-generic/spine-generic/issues/220