### PR TITLE
Fix inconsistencies in proces_data.sh comments

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -279,7 +279,7 @@ mv warp_${file_dwi_mean}2PAM50_t1.nii.gz warp_dwi2template.nii.gz
 sct_warp_template -d ${file_dwi_mean}.nii.gz -w warp_template2dwi.nii.gz -qc ${PATH_QC} -qc-subject ${SUBJECT}
 # Create mask around the spinal cord (for faster computing)
 sct_maths -i ${file_dwi_seg}.nii.gz -dilate 1 -shape ball -o ${file_dwi_seg}_dil.nii.gz
-# Compute DTI using RESTORE
+# Compute DTI
 sct_dmri_compute_dti -i ${file_dwi}.nii.gz -bvec ${file_bvec} -bval ${file_bval} -method standard -m ${file_dwi_seg}_dil.nii.gz
 # Compute FA, MD and RD in WM between C2 and C5 vertebral levels
 sct_extract_metric -i dti_FA.nii.gz -f label/atlas -l 51 -vert 2:5 -o ${PATH_RESULTS}/DWI_FA.csv -append 1

--- a/process_data.sh
+++ b/process_data.sh
@@ -153,7 +153,7 @@ file_t1="${file_t1}_RPI_r"
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist $file_t1 "t1"
 file_t1_seg=$FILESEG
-# Create labels in the cord at C2 and C5 mid-vertebral levels (only if it does not exist)
+# Create mid-vertebral levels in the cord (only if it does not exist)
 label_if_does_not_exist ${file_t1} ${file_t1_seg}
 file_label=$FILELABEL
 # Register to PAM50 template


### PR DESCRIPTION
This PR fixes two inconsistencies in `process_data.sh` comments:

- remove info about `RESTORE` algorithm - https://github.com/spine-generic/spine-generic/issues/169
- remove duplication of information regarding position of labels - https://github.com/spine-generic/spine-generic/issues/223

Fixes: #169 Fixes #223 