### PR TITLE
Compute min, max and median age across subjects

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -234,6 +234,12 @@ def aggregate_per_site(dict_results, metric, dict_exclude_subj):
     # Build Panda DF of participants based on participants.tsv file
     participants = pd.read_csv(os.path.join('participants.tsv'), sep="\t")
 
+    # Compute min, max and median for age across all subjects and save it to log
+    age_stat = participants['age'].agg(['median', 'min', 'max'])
+    logger.info('..., age between {} and {} y.o., median age {} y.o..'.format(age_stat['min'],
+                                                                              age_stat['max'],
+                                                                              age_stat['median']))
+
     # Fetch specific field for the selected metric
     metric_field = metric_to_field[metric]
     # Build a dictionary that aggregates values per site


### PR DESCRIPTION
This PR adds computation of min, max and median age across subjects from `participants.tsv` file
These stats are computed across all subjects (i.e., no exclusion is used).
Stats are then saved in form of prepared sentence for manuscript into `log_stats.txt` file:

`..., age between 19.0 and 56.0 y.o., median age 28.0 y.o..`

~~Known disadvantage of proposed solution - participants file is read for every metric in `aggregate_per_site` function:~~
 https://github.com/spine-generic/spine-generic/blob/de8b6c9df0e4a28ad418be7f990cf726cb7e6bfd/spinegeneric/cli/generate_figure.py#L234-L235
~~Then, age stats are also saved into `log_stats.txt` file for every metric separately. I could add some counter to save age only one time. Should I?~~

UPDATE: separate function was created https://github.com/spine-generic/spine-generic/pull/226/commits/d3975dfd9ed037f3ab8535bbb488a233a5645678, printing age stats only once