### PR TITLE
Force two decimal digits in regression box in t1-t2 agreement figure

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -756,7 +756,8 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
                                np.array(CSA_dict[vendor + '_t1']).reshape(-1, 1))
         # Place regression equation to upper-left corner
         plt.text(0.1, 0.9,
-                 "y = {0:.4}x + {1:.4}\nR\u00b2 = {2:.4}".format(float(slope), float(intercept), float(r2_sc)),
+                 'y = ' + format(float(slope), '.2f') + 'x + ' + format(float(intercept), '.2f') + '\nR\u00b2 = ' +
+                 format(float(r2_sc), '.2f'),       # force two decimal digits
                  ha='left', va='center', transform = ax.transAxes, fontsize=TICKSIZE, color='red',
                  bbox=dict(boxstyle='round', facecolor='white', alpha=1))   # box around equation
         # Plot linear fit

--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -671,6 +671,14 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
         r2_sc = linear_regression.score(x, y)
         return intercept, slope, reg_predictor, r2_sc
 
+    def format_number(number):
+        """
+        Round number to two decimals
+        :param number: input number
+        :return: number rounded to two decimals
+        """
+        return format(float(number), '.2f')
+
     # Sort values per vendor
     site_sorted = df.sort_values(by=['vendor', 'model', 'site']).index.values
     vendor_sorted = df['vendor'][site_sorted].values
@@ -755,9 +763,9 @@ def generate_figure_t1_t2(df, csa_t1, csa_t2):
             compute_regression(np.array(CSA_dict[vendor + '_t2']).reshape(-1, 1),
                                np.array(CSA_dict[vendor + '_t1']).reshape(-1, 1))
         # Place regression equation to upper-left corner
-        plt.text(0.1, 0.9,
-                 'y = ' + format(float(slope), '.2f') + 'x + ' + format(float(intercept), '.2f') + '\nR\u00b2 = ' +
-                 format(float(r2_sc), '.2f'),       # force two decimal digits
+        plt.text(0.1, 0.9, 'y = {}x + {}\nR\u00b2 = {}'.format(format_number(slope),
+                                                               format_number(intercept),
+                                                               format_number(r2_sc)),
                  ha='left', va='center', transform = ax.transAxes, fontsize=TICKSIZE, color='red',
                  bbox=dict(boxstyle='round', facecolor='white', alpha=1))   # box around equation
         # Plot linear fit


### PR DESCRIPTION
This PR force two decimal digits in regression box in t1-t2 agreement figure:

![fig_t1_t2_agreement_per_vendor](https://user-images.githubusercontent.com/39456460/94335235-6aeb9980-ffda-11ea-9d90-3f356f839544.png)

Fixes https://github.com/spine-generic/spine-generic/issues/227