### PR TITLE
Add preprocessing and keep segmentation only

### DIFF
--- a/curate_derivatives_spine_generic.py
+++ b/curate_derivatives_spine_generic.py
@@ -75,6 +75,24 @@ def remove_suffix(fname, suffix):
     return os.path.join(stem.replace(suffix, '') + ext)
 
 
+def curate_csgseg(fname):
+    """
+    Reorient to RPI and resample _csg_seg-manual.nii.gz images.
+    :param fname: absolute or relative file to curate.
+    :return: reoriented and resampled image.
+    """
+    os.system('sct_image -i {} -setorient RPI -o {}'.format(fname, sg.utils.add_suffix(fname, '_RPI')))
+    os.system('sct_resample -i {} -mm 0.8x0.8x0.8 -o {}'.format(sg.utils.add_suffix(fname, '_RPI'), sg.utils.add_suffix(fname, '_RPI_r')))
+
+    try:
+        os.remove(fname)
+        os.remove(sg.utils.add_suffix(fname, '_RPI'))
+    except OSError as e:  ## if failed, report it back to the user ##
+        print ("Error: %s - %s." % (e.filename, e.strerror))
+
+    shutil.move(sg.utils.add_suffix(fname, '_RPI_r'), fname)
+
+
 def main():
     parser = get_parser()
     args = parser.parse_args()
@@ -97,9 +115,10 @@ def main():
         subject = sg.bids.get_subject(file)
         contrast = get_contrast(file)
         if contrast=='dwi':
-            file_curated = subject + '_rec-average_dwi_seg-manual.nii.gz'
+            file_curated = subject + '_rec-average_dwi_seg-manual.nii.gz' # Rename 
         else:
-            file_curated = remove_suffix(file, '_RPI_r')
+            file_curated = remove_suffix(file, '_RPI_r') # Remove suffix on T1w and T2w images
+            file_curated = remove_suffix(file_curated, '_rms') # Remove suffix on T2star images
         # Append file to list.    
         manual_correction_list['FILES_SEG'].append(remove_suffix(file_curated, '_seg-manual'))
         fname = os.path.join(args.path_in, subject, contrast, file)
@@ -108,6 +127,10 @@ def main():
         os.makedirs(os.path.join(path_out_deriv, subject, contrast), exist_ok=True)
         shutil.copy(fname, fname_label)
         
+        # Reorient and resample csfseg
+        if 'csfseg-manual.nii.gz' in fname_label.split('_'):
+            curate_csgseg(fname_label)
+
         # create json sidecar with the name of the expert rater if it doesn't exist.
         fname_json = fname.rstrip('.nii').rstrip('.nii.gz') + '.json'
         if not os.path.isfile(fname_json):
@@ -115,6 +138,7 @@ def main():
         else:
             fname_json_curated = fname_label.rstrip('.nii').rstrip('.nii.gz') + '.json'
             shutil.copy(fname_json, fname_json_curated)
+    # Create a yml list with the name of the derivatives.
     with open(os.path.join(args.path_out, 'manual_seg.yml'), 'w') as file:
         yaml.dump(manual_correction_list, file)
 

--- a/curate_derivatives_spine_generic.py
+++ b/curate_derivatives_spine_generic.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# For usage, type: python curate_derivatives_spine_generic.py -h
+#
+# Authors: Sandrine Bédard
+
+import argparse
+import glob
+import os
+import shutil
+
+import spinegeneric as sg
+import spinegeneric.cli.manual_correction
+import spinegeneric.utils
+import spinegeneric.bids
+
+FOLDER_DERIVATIVES = os.path.join('derivatives', 'labels')
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Gets derivatives with label _seg-manual, removes suffix _RPI_r, creates json sidecar and creates a new curated derivatives folder." )
+    parser.add_argument('-path-in', required=True, type=str,
+                        help="Input path to derivatives folder to curate.")
+    parser.add_argument('-path-out', required=True, type=str,
+                        help="Ouput curated derivatives folder.")
+
+    return parser
+
+
+def get_contrast(file):
+    """
+    Get contrast from BIDS file name
+    :param file:
+    :return:
+    """
+    if 'dwi' in file.split('_'):
+        return 'dwi'
+    else:
+        return 'anat'
+
+
+def splitext(fname):
+    """
+    Split a fname (folder/file + ext) into a folder/file and extension.
+
+    Note: for .nii.gz the extension is understandably .nii.gz, not .gz
+    (``os.path.splitext()`` would want to do the latter, hence the special case).
+    """
+    dir, filename = os.path.split(fname)
+    for special_ext in ['.nii.gz', '.tar.gz']:
+        if filename.endswith(special_ext):
+            stem, ext = filename[:-len(special_ext)], special_ext
+            return os.path.join(dir, stem), ext
+    # If no special case, behaves like the regular splitext
+    stem, ext = os.path.splitext(filename)
+    return os.path.join(dir, stem), ext
+
+
+def remove_suffix(fname, suffix):
+    """
+    Remove suffix between end of file name and extension.
+
+    :param fname: absolute or relative file name with suffix. Example: t2_mean.nii
+    :param suffix: suffix. Example: _mean
+    :return: file name without suffix. Example: t2.nii
+
+    Examples:
+
+    - remove_suffix(t2_mean.nii, _mean) -> t2.nii
+    - remove_suffix(t2a.nii.gz, a) -> t2.nii.gz
+    """
+    stem, ext = splitext(fname)
+    return os.path.join(stem.replace(suffix, '') + ext)
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    # check that output folder exists and has write permission
+    path_out_deriv = sg.utils.check_output_folder(args.path_out, FOLDER_DERIVATIVES)
+
+    name_rater = input("Enter your name (Firstname Lastname). It will be used to generate a json sidecar with each "
+                           "corrected file: ")
+
+    path_list = glob.glob(args.path_in + "/**/*seg-manual.nii.gz", recursive=True) # TODO: add other extension
+    # Get only filenames without suffix _seg  to match files in -config .yml list
+    file_list = [os.path.split(path)[-1] for path in path_list]
+
+    for file in file_list:
+        # build file names
+        subject = sg.bids.get_subject(file)
+        contrast = get_contrast(file)
+        if contrast=='dwi':
+            file_curated = subject + '_rec-average_dwi_seg-manual.nii.gz'
+        else:
+            file_curated = remove_suffix(file, '_RPI_r')
+        fname = os.path.join(args.path_in, subject, contrast, file)
+        fname_label = os.path.join(
+            path_out_deriv, subject, contrast, file_curated)
+        os.makedirs(os.path.join(path_out_deriv, subject, contrast), exist_ok=True)
+        shutil.copy(fname, fname_label)
+        
+        # create json sidecar with the name of the expert rater
+        fname_json = fname.rstrip('.nii').rstrip('.nii.gz') + '.json'
+        if not os.path.isfile(fname_json):
+            sg.cli.manual_correction.create_json(fname_label, name_rater)
+        else:
+            fname_json_curated = fname_label.rstrip('.nii').rstrip('.nii.gz') + '.json'
+            shutil.copy(fname_json, fname_json_curated)
+
+if __name__ == '__main__':
+    main()

--- a/curate_derivatives_spine_generic.py
+++ b/curate_derivatives_spine_generic.py
@@ -23,7 +23,7 @@ def get_parser():
     parser = argparse.ArgumentParser(
         description="Gets derivatives with label _seg-manual, removes suffix _RPI_r, creates json sidecar if it does not exist and creates a new curated derivatives folder. Ouptuts a .yml list with all manually corrected files." )
     parser.add_argument('-path-in', required=True, type=str,
-                        help="Input path to derivatives folder to curate.")
+                        help="Input path to derivatives folder to curate. Example: /derivatives/labels/")
     parser.add_argument('-path-out', required=True, type=str,
                         help="Output curated derivatives folder.")
     return parser
@@ -90,7 +90,7 @@ def main():
     file_list = [os.path.split(path)[-1] for path in path_list]
 
     # Initialize empty dict to create a list of all corrected files.
-    manual_correction_list = {'FILESEG':[]}
+    manual_correction_list = {'FILES_SEG':[]}
 
     for file in file_list:
         # build file names
@@ -101,7 +101,7 @@ def main():
         else:
             file_curated = remove_suffix(file, '_RPI_r')
         # Append file to list.    
-        manual_correction_list['FILESEG'].append(file_curated)
+        manual_correction_list['FILES_SEG'].append(remove_suffix(file_curated, '_seg-manual'))
         fname = os.path.join(args.path_in, subject, contrast, file)
         fname_label = os.path.join(
             path_out_deriv, subject, contrast, file_curated)

--- a/curate_derivatives_spine_generic.py
+++ b/curate_derivatives_spine_generic.py
@@ -21,7 +21,7 @@ FOLDER_DERIVATIVES = os.path.join('derivatives', 'labels')
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Gets derivatives with label _seg-manual, removes suffix _RPI_r, creates json sidecar if it does not exist and creates a new curated derivatives folder. Ouptuts a .yml list with all manually corrected files." )
+        description="Gets derivatives with label _seg-manual, removes suffix _RPI_r or _rms, creates json sidecar if it does not exist and creates a new curated derivatives folder. Ouptuts a .yml list with all manually corrected files." )
     parser.add_argument('-path-in', required=True, type=str,
                         help="Input path to derivatives folder to curate. Example: /derivatives/labels/")
     parser.add_argument('-path-out', required=True, type=str,
@@ -79,7 +79,7 @@ def curate_csgseg(fname):
     """
     Reorient to RPI and resample _csg_seg-manual.nii.gz images.
     :param fname: absolute or relative file to curate.
-    :return: reoriented and resampled image.
+    :return:
     """
     os.system('sct_image -i {} -setorient RPI -o {}'.format(fname, sg.utils.add_suffix(fname, '_RPI')))
     os.system('sct_resample -i {} -mm 0.8x0.8x0.8 -o {}'.format(sg.utils.add_suffix(fname, '_RPI'), sg.utils.add_suffix(fname, '_RPI_r')))

--- a/preprocess_data.sh
+++ b/preprocess_data.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#
+# Preprocess data. 
+#     For T1w and T2w : From raw images, proceeds to resampling and reorientation to RPI.
+#     For T2s : Compute root-mean square across 4th dimension (if it exists)
+#     For dwi : Generate mean image after motion correction.
+#
+# Usage:
+#   ./preprocess_data.sh <SUBJECT>
+#
+#
+# Authors: Julien Cohen-Adad, Sandrine Bédard
+
+# The following global variables are retrieved from the caller sct_run_batch
+# but could be overwritten by uncommenting the lines below:
+# PATH_DATA_PROCESSED="~/data_processed"
+# PATH_RESULTS="~/results"
+# PATH_LOG="~/log"
+# PATH_QC="~/qc"
+
+# Uncomment for full verbose
+set -x
+
+# Immediately exit if error
+set -e -o pipefail
+
+# Exit if user presses CTRL+C (Linux) or CMD+C (OSX)
+trap "echo Caught Keyboard Interrupt within script. Exiting now.; exit" INT
+
+# Retrieve input params
+SUBJECT=$1
+
+# get starting time:
+start=`date +%s`
+
+# SCRIPT STARTS HERE
+# ==============================================================================
+# Display useful info for the log, such as SCT version, RAM and CPU cores available
+sct_check_dependencies -short
+
+# Go to folder where data will be copied and processed
+cd $PATH_DATA_PROCESSED
+# Copy list of participants in processed data folder
+if [[ ! -f "participants.tsv" ]]; then
+  rsync -avzh $PATH_DATA/participants.tsv .
+fi
+# Copy list of participants in results folder (used by spine-generic scripts)
+if [[ ! -f $PATH_RESULTS/"participants.tsv" ]]; then
+  rsync -avzh $PATH_DATA/participants.tsv $PATH_RESULTS/"participants.tsv"
+fi
+# Copy source images
+rsync -avzh $PATH_DATA/$SUBJECT .
+# Go to anat folder where all structural data are located
+cd ${SUBJECT}/anat/
+
+
+# FUNCTIONS
+# ==============================================================================
+
+# If there is an additional b=0 scan, add it to the main DWI data and update the
+# bval and bvec files.
+concatenate_b0_and_dwi(){
+  local file_b0="$1"  # does not have extension
+  local file_dwi="$2"  # does not have extension
+  if [[ -e ${file_b0}.nii.gz ]]; then
+    echo "Found additional b=0 scans: $file_b0.nii.gz They will be concatenated to the DWI scans."
+    sct_dmri_concat_b0_and_dwi -i ${file_b0}.nii.gz ${file_dwi}.nii.gz -bval ${file_dwi}.bval -bvec ${file_dwi}.bvec -order b0 dwi -o ${file_dwi}_concat.nii.gz -obval ${file_dwi}_concat.bval -obvec ${file_dwi}_concat.bvec
+    # Update global variable
+    FILE_DWI="${file_dwi}_concat"
+  else
+    echo "No additional b=0 scans was found."
+    FILE_DWI="${file_dwi}"
+  fi
+}
+
+
+# T1w
+# ------------------------------------------------------------------------------
+file_t1="${SUBJECT}_T1w"
+# Rename the raw image
+mv ${file_t1}.nii.gz ${file_t1}_raw.nii.gz
+file_t1="${file_t1}_raw"
+
+# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution)
+sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
+sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
+file_t1="${file_t1}_RPI_r"
+
+# Rename _RPI_r file
+mv ${file_t1}.nii.gz ${SUBJECT}_T1w.nii.gz
+
+# Delete raw and reoriented to RPI images
+rm -f ${SUBJECT}_T1w_raw.nii.gz ${SUBJECT}_T1w_raw_RPI.nii.gz
+
+
+# T2
+# ------------------------------------------------------------------------------
+file_t2="${SUBJECT}_T2w"
+# Rename raw file
+mv ${file_t2}.nii.gz ${file_t2}_raw.nii.gz
+file_t2="${file_t2}_raw"
+
+# Reorient to RPI and resample to 0.8mm iso (supposed to be the effective resolution)
+sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
+sct_resample -i ${file_t2}_RPI.nii.gz -mm 0.8x0.8x0.8 -o ${file_t2}_RPI_r.nii.gz
+file_t2="${file_t2}_RPI_r"
+
+# Rename _RPI_r file
+mv ${file_t2}.nii.gz ${SUBJECT}_T2w.nii.gz
+
+# Delete raw, reoriented to RPI images
+rm -f ${SUBJECT}_T2w_raw.nii.gz ${SUBJECT}_T2w_raw_RPI.nii.gz
+
+
+# T2s
+# ------------------------------------------------------------------------------
+file_t2s="${SUBJECT}_T2star"
+# Rename raw file
+mv ${file_t2s}.nii.gz ${file_t2s}_raw.nii.gz
+file_t2s="${file_t2s}_raw"
+
+# Compute root-mean square across 4th dimension (if it exists), corresponding to all echoes in Philips scans.
+sct_maths -i ${file_t2s}.nii.gz -rms t -o ${file_t2s}_rms.nii.gz
+file_t2s="${file_t2s}_rms"
+
+# Rename _rms file
+mv ${file_t2s}.nii.gz ${SUBJECT}_T2star.nii.gz
+
+# Delete raw images
+rm -f ${SUBJECT}_T2star_raw.nii.gz
+
+
+# DWI
+# ------------------------------------------------------------------------------
+file_dwi="${SUBJECT}_dwi"
+cd ../dwi
+# If there is an additional b=0 scan, add it to the main DWI data
+concatenate_b0_and_dwi "${SUBJECT}_acq-b0_dwi" $file_dwi
+file_dwi=$FILE_DWI
+file_bval=${file_dwi}.bval
+file_bvec=${file_dwi}.bvec
+# Separate b=0 and DW images
+sct_dmri_separate_b0_and_dwi -i ${file_dwi}.nii.gz -bvec ${file_bvec}
+# Get centerline
+sct_get_centerline -i ${file_dwi}_dwi_mean.nii.gz -c dwi -qc ${PATH_QC} -qc-subject ${SUBJECT}
+# Create mask to help motion correction and for faster processing
+sct_create_mask -i ${file_dwi}_dwi_mean.nii.gz -p centerline,${file_dwi}_dwi_mean_centerline.nii.gz -size 30mm
+# Motion correction
+sct_dmri_moco -i ${file_dwi}.nii.gz -bvec ${file_dwi}.bvec -m mask_${file_dwi}_dwi_mean.nii.gz -x spline
+
+# Remove intermediate files, Do we rename file_dwi_mean??
+if [[ -e ${SUBJECT}_acq-b0_dwi.nii.gz ]]; then
+    rm -f mask_${FILE_DWI}_dwi_mean.nii.gz moco_params.tsv moco_params_x.nii.gz moco_params_y.nii.gz ${FILE_DWI}.bval ${FILE_DWI}.bvec ${FILE_DWI}.nii.gz ${FILE_DWI}_b0.nii.gz ${FILE_DWI}_b0_mean.nii.gz ${FILE_DWI}_dwi.nii.gz ${FILE_DWI}_dwi_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.nii.gz ${FILE_DWI}_moco.nii.gz ${FILE_DWI}_moco_b0_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.csv
+else
+    rm -f mask_${FILE_DWI}_dwi_mean.nii.gz moco_params.tsv moco_params_x.nii.gz moco_params_y.nii.gz ${FILE_DWI}_b0.nii.gz ${FILE_DWI}_b0_mean.nii.gz ${FILE_DWI}_dwi.nii.gz ${FILE_DWI}_dwi_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.nii.gz ${FILE_DWI}_moco.nii.gz ${FILE_DWI}_moco_b0_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.csv
+fi
+
+# Go back to parent folder
+cd ..
+
+# Verify presence of output files and write log file if error
+# ------------------------------------------------------------------------------
+FILES_TO_CHECK=(
+  "anat/${SUBJECT}_T1w.nii.gz"
+  "anat/${SUBJECT}_T2w.nii.gz"
+  "anat/${SUBJECT}_T2star.nii.gz"
+  "dwi/${FILE_DWI}_moco_dwi_mean.nii.gz" # Maybe to change --> if we rename
+  
+)
+pwd
+for file in ${FILES_TO_CHECK[@]}; do
+  if [[ ! -e $file ]]; then
+    echo "${SUBJECT}/anat/${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
+  fi
+done
+
+# Display useful info for the log
+end=`date +%s`
+runtime=$((end-start))
+echo
+echo "~~~"
+echo "SCT version: `sct_version`"
+echo "Ran on:      `uname -nsr`"
+echo "Duration:    $(($runtime / 3600))hrs $((($runtime / 60) % 60))min $(($runtime % 60))sec"
+echo "~~~"

--- a/preprocess_data.sh
+++ b/preprocess_data.sh
@@ -148,7 +148,10 @@ sct_create_mask -i ${file_dwi}_dwi_mean.nii.gz -p centerline,${file_dwi}_dwi_mea
 # Motion correction
 sct_dmri_moco -i ${file_dwi}.nii.gz -bvec ${file_dwi}.bvec -m mask_${file_dwi}_dwi_mean.nii.gz -x spline
 
-# Remove intermediate files, Do we rename file_dwi_mean??
+# Rename _moco_dwi_mean file
+mv ${FILE_DWI}_moco_dwi_mean.nii.gz ${SUBJECT}_rec-average_dwi.nii.gz
+
+# Remove intermediate files
 if [[ -e ${SUBJECT}_acq-b0_dwi.nii.gz ]]; then
     rm -f mask_${FILE_DWI}_dwi_mean.nii.gz moco_params.tsv moco_params_x.nii.gz moco_params_y.nii.gz ${FILE_DWI}.bval ${FILE_DWI}.bvec ${FILE_DWI}.nii.gz ${FILE_DWI}_b0.nii.gz ${FILE_DWI}_b0_mean.nii.gz ${FILE_DWI}_dwi.nii.gz ${FILE_DWI}_dwi_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.nii.gz ${FILE_DWI}_moco.nii.gz ${FILE_DWI}_moco_b0_mean.nii.gz ${FILE_DWI}_dwi_mean_centerline.csv
 else
@@ -164,8 +167,7 @@ FILES_TO_CHECK=(
   "anat/${SUBJECT}_T1w.nii.gz"
   "anat/${SUBJECT}_T2w.nii.gz"
   "anat/${SUBJECT}_T2star.nii.gz"
-  "dwi/${FILE_DWI}_moco_dwi_mean.nii.gz" # Maybe to change --> if we rename
-  
+  "dwi/${SUBJECT}_rec-average_dwi.nii.gz"
 )
 pwd
 for file in ${FILES_TO_CHECK[@]}; do

--- a/process_data.sh
+++ b/process_data.sh
@@ -124,14 +124,8 @@ segment_if_does_not_exist $file_t2 "t2"
 file_t1w="${SUBJECT}_acq-T1w_MTS"
 file_mton="${SUBJECT}_acq-MTon_MTS"
 
-if [[ -e "${file_t1w}.nii.gz" && -e "${file_mton}.nii.gz" && -e "${file_mtoff}.nii.gz" ]]; then 
-  # Segment spinal cord (only if it does not exist)
-  segment_if_does_not_exist $file_t1w "t1" 
-  segment_if_does_not_exist $file_mton "t2s"
- 
-else
-  echo "WARNING: MTS dataset is incomplete."
-fi
+segment_if_does_not_exist $file_t1w "t1" 
+segment_if_does_not_exist $file_mton "t2s"
 
 
 # T2s

--- a/process_data.sh
+++ b/process_data.sh
@@ -148,18 +148,8 @@ segment_gm_if_does_not_exist $file_t2s "t2s"
 
 # DWI
 # ------------------------------------------------------------------------------
-file_dwi="${SUBJECT}_dwi"
 cd ../dwi
-if [[ -e ${SUBJECT}_acq-b0_dwi.nii.gz ]]; then
-  echo "Found additional b=0 scans: $file_b0.nii.gz"
-  # Update global variable
-  FILE_DWI="${file_dwi}_concat"
-else
-  echo "No additional b=0 scans was found."
-  FILE_DWI="${file_dwi}"
-fi
-
-file_dwi_mean="${FILE_DWI}_moco_dwi_mean" # TO RENAME
+file_dwi_mean="${SUBJECT}_rec-average_dwi"
 
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist ${file_dwi_mean} "dwi"
@@ -176,7 +166,7 @@ FILES_TO_CHECK=(
   "anat/${SUBJECT}_acq-MTon_MTS_seg.nii.gz"
   "anat/${SUBJECT}_T2star_seg.nii.gz"
   "anat/${SUBJECT}_T2star_gmseg.nii.gz"
-  "dwi/${FILE_DWI}_moco_dwi_mean_seg.nii.gz" # MAYBE change if we rename
+  "dwi${SUBJECT}_rec-average_dwi_seg.nii.gz"
 )
 for file in ${FILES_TO_CHECK[@]}; do
   if [[ ! -e $file ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Process data.
+# Process data, modfified version to only create SC segmentations and GM segmentation for T2s. Uses spine-generic-processed as an input.
 #
 # Usage:
 #   ./process_data.sh <SUBJECT>
@@ -8,7 +8,7 @@
 # Manual segmentations or labels should be located under:
 # PATH_DATA/derivatives/labels/SUBJECT/<CONTRAST>/
 #
-# Authors: Julien Cohen-Adad
+# Authors: Julien Cohen-Adad, Sandrine Bédard
 
 # The following global variables are retrieved from the caller sct_run_batch
 # but could be overwritten by uncommenting the lines below:
@@ -35,43 +35,6 @@ start=`date +%s`
 
 # FUNCTIONS
 # ==============================================================================
-
-# If there is an additional b=0 scan, add it to the main DWI data and update the
-# bval and bvec files.
-concatenate_b0_and_dwi(){
-  local file_b0="$1"  # does not have extension
-  local file_dwi="$2"  # does not have extension
-  if [[ -e ${file_b0}.nii.gz ]]; then
-    echo "Found additional b=0 scans: $file_b0.nii.gz They will be concatenated to the DWI scans."
-    sct_dmri_concat_b0_and_dwi -i ${file_b0}.nii.gz ${file_dwi}.nii.gz -bval ${file_dwi}.bval -bvec ${file_dwi}.bvec -order b0 dwi -o ${file_dwi}_concat.nii.gz -obval ${file_dwi}_concat.bval -obvec ${file_dwi}_concat.bvec
-    # Update global variable
-    FILE_DWI="${file_dwi}_concat"
-  else
-    echo "No additional b=0 scans was found."
-    FILE_DWI="${file_dwi}"
-  fi
-}
-
-# Check if manual label already exists. If it does, copy it locally. If it does
-# not, perform labeling.
-label_if_does_not_exist(){
-  local file="$1"
-  local file_seg="$2"
-  # Update global variable with segmentation file name
-  FILELABEL="${file}_labels"
-  FILELABELMANUAL="${PATH_DATA}/derivatives/labels/${SUBJECT}/anat/${FILELABEL}-manual.nii.gz"
-  echo "Looking for manual label: $FILELABELMANUAL"
-  if [[ -e $FILELABELMANUAL ]]; then
-    echo "Found! Using manual labels."
-    rsync -avzh $FILELABELMANUAL ${FILELABEL}.nii.gz
-  else
-    echo "Not found. Proceeding with automatic labeling."
-    # Generate labeled segmentation
-    sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -c t1
-    # Create labels in the cord at C3 and C5 mid-vertebral levels
-    sct_label_utils -i ${file_seg}_labeled.nii.gz -vert-body 3,5 -o ${FILELABEL}.nii.gz
-  fi
-}
 
 # Check if manual segmentation already exists. If it does, copy it locally. If
 # it does not, perform seg.
@@ -121,7 +84,6 @@ segment_gm_if_does_not_exist(){
 }
 
 
-
 # SCRIPT STARTS HERE
 # ==============================================================================
 # Display useful info for the log, such as SCT version, RAM and CPU cores available
@@ -146,46 +108,16 @@ cd ${SUBJECT}/anat/
 # T1w
 # ------------------------------------------------------------------------------
 file_t1="${SUBJECT}_T1w"
-# Reorient to RPI and resample to 1mm iso (supposed to be the effective resolution)
-sct_image -i ${file_t1}.nii.gz -setorient RPI -o ${file_t1}_RPI.nii.gz
-sct_resample -i ${file_t1}_RPI.nii.gz -mm 1x1x1 -o ${file_t1}_RPI_r.nii.gz
-file_t1="${file_t1}_RPI_r"
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist $file_t1 "t1"
-file_t1_seg=$FILESEG
-# Create mid-vertebral levels in the cord (only if it does not exist)
-label_if_does_not_exist ${file_t1} ${file_t1_seg}
-file_label=$FILELABEL
-# Register to PAM50 template
-sct_register_to_template -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz -l ${file_label}.nii.gz -c t1 -param step=1,type=seg,algo=centermassrot:step=2,type=seg,algo=syn,slicewise=1,smooth=0,iter=5:step=3,type=im,algo=syn,slicewise=1,smooth=0,iter=3 -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# Rename warping fields for clarity
-mv warp_template2anat.nii.gz warp_template2T1w.nii.gz
-mv warp_anat2template.nii.gz warp_T1w2template.nii.gz
-# Warp template without the white matter atlas (we don't need it at this point)
-sct_warp_template -d ${file_t1}.nii.gz -w warp_template2T1w.nii.gz -a 0 -ofolder label_T1w
-# Generate QC report to assess vertebral labeling
-sct_qc -i ${file_t1}.nii.gz -s label_T1w/template/PAM50_levels.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# Flatten scan along R-L direction (to make nice figures)
-sct_flatten_sagittal -i ${file_t1}.nii.gz -s ${file_t1_seg}.nii.gz
-# Compute average cord CSA between C2 and C3
-sct_process_segmentation -i ${file_t1_seg}.nii.gz -vert 2:3 -vertfile label_T1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/csa-SC_T1w.csv -append 1
 
-# T2
+
+# T2w
 # ------------------------------------------------------------------------------
 file_t2="${SUBJECT}_T2w"
-# Reorient to RPI and resample to 0.8mm iso (supposed to be the effective resolution)
-sct_image -i ${file_t2}.nii.gz -setorient RPI -o ${file_t2}_RPI.nii.gz
-sct_resample -i ${file_t2}_RPI.nii.gz -mm 0.8x0.8x0.8 -o ${file_t2}_RPI_r.nii.gz
-file_t2="${file_t2}_RPI_r"
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist $file_t2 "t2"
-file_t2_seg=$FILESEG
-# Flatten scan along R-L direction (to make nice figures)
-sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
-# Bring vertebral level into T2 space
-sct_register_multimodal -i label_T1w/template/PAM50_levels.nii.gz -d ${file_t2_seg}.nii.gz -o PAM50_levels2${file_t2}.nii.gz -identity 1 -x nn
-# Compute average cord CSA between C2 and C3
-sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile PAM50_levels2${file_t2}.nii.gz -o ${PATH_RESULTS}/csa-SC_T2w.csv -append 1
+
 
 # MTS
 # ------------------------------------------------------------------------------
@@ -193,115 +125,60 @@ file_t1w="${SUBJECT}_acq-T1w_MTS"
 file_mton="${SUBJECT}_acq-MTon_MTS"
 file_mtoff="${SUBJECT}_acq-MToff_MTS"
 
-if [[ -e "${file_t1w}.nii.gz" && -e "${file_mton}.nii.gz" && -e "${file_mtoff}.nii.gz" ]]; then
+if [[ -e "${file_t1w}.nii.gz" && -e "${file_mton}.nii.gz" && -e "${file_mtoff}.nii.gz" ]]; then 
   # Segment spinal cord (only if it does not exist)
-  segment_if_does_not_exist $file_t1w "t1"
-  file_t1w_seg=$FILESEG
-  # Create mask
-  sct_create_mask -i ${file_t1w}.nii.gz -p centerline,${file_t1w_seg}.nii.gz -size 35mm -o ${file_t1w}_mask.nii.gz
-  # Crop data for faster processing
-  sct_crop_image -i ${file_t1w}.nii.gz -m ${file_t1w}_mask.nii.gz -o ${file_t1w}_crop.nii.gz
-  file_t1w="${file_t1w}_crop"
-  # Register PD->T1w
-  # Tips: here we only use rigid transformation because both images have very similar sequence parameters. We don't want to use SyN/BSplineSyN to avoid introducing spurious deformations.
-  sct_register_multimodal -i ${file_mtoff}.nii.gz -d ${file_t1w}.nii.gz -dseg ${file_t1w_seg}.nii.gz -param step=1,type=im,algo=rigid,slicewise=1,metric=CC -x spline -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  file_mtoff="${file_mtoff}_reg"
-  # Register MT->T1w
-  sct_register_multimodal -i ${file_mton}.nii.gz -d ${file_t1w}.nii.gz -dseg ${file_t1w_seg}.nii.gz -param step=1,type=im,algo=rigid,slicewise=1,metric=CC -x spline -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  file_mton="${file_mton}_reg"
-  # Copy json files to match file basename (it will later be used by sct_compute_mtsat)
-  cp ${SUBJECT}_acq-T1w_MTS.json ${file_t1w}.json
-  cp ${SUBJECT}_acq-MToff_MTS.json ${file_mtoff}.json
-  cp ${SUBJECT}_acq-MTon_MTS.json ${file_mton}.json
-  # Register template->T1w_ax (using template-T1w as initial transformation)
-  sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -d ${file_t1w}.nii.gz -dseg ${file_t1w_seg}.nii.gz -param step=1,type=seg,algo=slicereg,metric=MeanSquares,smooth=2:step=2,type=im,algo=syn,metric=CC,iter=5,gradStep=0.5 -initwarp warp_template2T1w.nii.gz -initwarpinv warp_T1w2template.nii.gz
-  # Rename warping field for clarity
-  mv warp_PAM50_t12${file_t1w}.nii.gz warp_template2axT1w.nii.gz
-  mv warp_${file_t1w}2PAM50_t1.nii.gz warp_axT1w2template.nii.gz
-  # Warp template
-  sct_warp_template -d ${file_t1w}.nii.gz -w warp_template2axT1w.nii.gz -ofolder label_axT1w -qc ${PATH_QC} -qc-subject ${SUBJECT}
-  # Compute MTR
-  sct_compute_mtr -mt0 ${file_mtoff}.nii.gz -mt1 ${file_mton}.nii.gz
-  # Compute MTsat
-  sct_compute_mtsat -mt ${file_mton}.nii.gz -pd ${file_mtoff}.nii.gz -t1 ${file_t1w}.nii.gz
-  # Extract MTR, MTsat and T1 in WM between C2 and C5 vertebral levels
-  sct_extract_metric -i mtr.nii.gz -f label_axT1w/atlas -l 51 -vert 2:5 -vertfile label_axT1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/MTR.csv -append 1
-  sct_extract_metric -i mtsat.nii.gz -f label_axT1w/atlas -l 51 -vert 2:5 -vertfile label_axT1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/MTsat.csv -append 1
-  sct_extract_metric -i t1map.nii.gz -f label_axT1w/atlas -l 51 -vert 2:5 -vertfile label_axT1w/template/PAM50_levels.nii.gz -o ${PATH_RESULTS}/T1.csv -append 1
+  segment_if_does_not_exist $file_t1w "t1" # Do we keep it or not?
+  segment_if_does_not_exist $file_mton "t2s" # or T2
+  #segment_if_does_not_exist $file_mtoff "t1" # or DWI or t1 = NO --> automatic segmentation doesn't work with sct_deepseg_sc
+ 
 else
   echo "WARNING: MTS dataset is incomplete."
 fi
 
+
 # T2s
 # ------------------------------------------------------------------------------
 file_t2s="${SUBJECT}_T2star"
-# Compute root-mean square across 4th dimension (if it exists), corresponding to all echoes in Philips scans.
-sct_maths -i ${file_t2s}.nii.gz -rms t -o ${file_t2s}_rms.nii.gz
-file_t2s="${file_t2s}_rms"
-# Bring vertebral level into T2s space
-sct_register_multimodal -i label_T1w/template/PAM50_levels.nii.gz -d ${file_t2s}.nii.gz -o PAM50_levels2${file_t2s}.nii.gz -identity 1 -x nn
+
+# Segment spinal cord (only if it does not exist)
+segment_if_does_not_exist $file_t2s "t2s"
+
 # Segment gray matter (only if it does not exist)
 segment_gm_if_does_not_exist $file_t2s "t2s"
-file_t2s_seg=$FILESEG
-# Compute the gray matter CSA between C3 and C4 levels
-# NB: Here we set -no-angle 1 because we do not want angle correction: it is too
-# unstable with GM seg, and t2s data were acquired orthogonal to the cord anyways.
-sct_process_segmentation -i ${file_t2s_seg}.nii.gz -angle-corr 0 -vert 3:4 -vertfile PAM50_levels2${file_t2s}.nii.gz -o ${PATH_RESULTS}/csa-GM_T2s.csv -append 1
+
 
 # DWI
 # ------------------------------------------------------------------------------
 file_dwi="${SUBJECT}_dwi"
 cd ../dwi
-# If there is an additional b=0 scan, add it to the main DWI data
-concatenate_b0_and_dwi "${SUBJECT}_acq-b0_dwi" $file_dwi
-file_dwi=$FILE_DWI
-file_bval=${file_dwi}.bval
-file_bvec=${file_dwi}.bvec
-# Separate b=0 and DW images
-sct_dmri_separate_b0_and_dwi -i ${file_dwi}.nii.gz -bvec ${file_bvec}
-# Get centerline
-sct_get_centerline -i ${file_dwi}_dwi_mean.nii.gz -c dwi -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# Create mask to help motion correction and for faster processing
-sct_create_mask -i ${file_dwi}_dwi_mean.nii.gz -p centerline,${file_dwi}_dwi_mean_centerline.nii.gz -size 30mm
-# Motion correction
-sct_dmri_moco -i ${file_dwi}.nii.gz -bvec ${file_dwi}.bvec -m mask_${file_dwi}_dwi_mean.nii.gz -x spline
-file_dwi=${file_dwi}_moco
-file_dwi_mean=${file_dwi}_dwi_mean
+if [[ -e ${SUBJECT}_acq-b0_dwi.nii.gz ]]; then
+  echo "Found additional b=0 scans: $file_b0.nii.gz"
+  # Update global variable
+  FILE_DWI="${file_dwi}_concat"
+else
+  echo "No additional b=0 scans was found."
+  FILE_DWI="${file_dwi}"
+fi
+
+file_dwi_mean="${FILE_DWI}_moco_dwi_mean"
+
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist ${file_dwi_mean} "dwi"
-file_dwi_seg=$FILESEG
-# Register template->dwi (using template-T1w as initial transformation)
-sct_register_multimodal -i $SCT_DIR/data/PAM50/template/PAM50_t1.nii.gz -iseg $SCT_DIR/data/PAM50/template/PAM50_cord.nii.gz -d ${file_dwi_mean}.nii.gz -dseg ${file_dwi_seg}.nii.gz -param step=1,type=seg,algo=centermass:step=2,type=im,algo=syn,metric=CC,iter=5,gradStep=0.5 -initwarp ../anat/warp_template2T1w.nii.gz -initwarpinv ../anat/warp_T1w2template.nii.gz
-# Rename warping field for clarity
-mv warp_PAM50_t12${file_dwi_mean}.nii.gz warp_template2dwi.nii.gz
-mv warp_${file_dwi_mean}2PAM50_t1.nii.gz warp_dwi2template.nii.gz
-# Warp template
-sct_warp_template -d ${file_dwi_mean}.nii.gz -w warp_template2dwi.nii.gz -qc ${PATH_QC} -qc-subject ${SUBJECT}
-# Create mask around the spinal cord (for faster computing)
-sct_maths -i ${file_dwi_seg}.nii.gz -dilate 1 -shape ball -o ${file_dwi_seg}_dil.nii.gz
-# Compute DTI
-sct_dmri_compute_dti -i ${file_dwi}.nii.gz -bvec ${file_bvec} -bval ${file_bval} -method standard -m ${file_dwi_seg}_dil.nii.gz
-# Compute FA, MD and RD in WM between C2 and C5 vertebral levels
-sct_extract_metric -i dti_FA.nii.gz -f label/atlas -l 51 -vert 2:5 -o ${PATH_RESULTS}/DWI_FA.csv -append 1
-sct_extract_metric -i dti_MD.nii.gz -f label/atlas -l 51 -vert 2:5 -o ${PATH_RESULTS}/DWI_MD.csv -append 1
-sct_extract_metric -i dti_RD.nii.gz -f label/atlas -l 51 -vert 2:5 -o ${PATH_RESULTS}/DWI_RD.csv -append 1
+
 # Go back to parent folder
 cd ..
 
 # Verify presence of output files and write log file if error
 # ------------------------------------------------------------------------------
 FILES_TO_CHECK=(
-  "anat/${SUBJECT}_T1w_RPI_r_seg.nii.gz"
-  "anat/${SUBJECT}_T2w_RPI_r_seg.nii.gz"
-  "anat/label_axT1w/template/PAM50_levels.nii.gz"
-  "anat/mtr.nii.gz"
-  "anat/mtsat.nii.gz"
-  "anat/t1map.nii.gz"
-  "anat/${SUBJECT}_T2star_rms_gmseg.nii.gz"
-  "dwi/dti_FA.nii.gz"
-  "dwi/dti_MD.nii.gz"
-  "dwi/dti_RD.nii.gz"
-  "dwi/label/atlas/PAM50_atlas_00.nii.gz"
+  "anat/${SUBJECT}_T1w_seg.nii.gz"
+  "anat/${SUBJECT}_T2w_seg.nii.gz"
+  "anat/${SUBJECT}_acq-T1w_MTS_seg.nii.gz" # Maybe remove
+  "anat/${SUBJECT}_acq-MTon_MTS_seg.nii.gz"
+  "anat/${SUBJECT}_acq-MToff_MTS_seg.nii.gz" # Maybe remove --> automatic seg fails
+  "anat/${SUBJECT}_T2star_seg.nii.gz"
+  "anat/${SUBJECT}_T2star_gmseg.nii.gz"
+  "dwi/${FILE_DWI}_moco_dwi_mean_seg.nii.gz" # MAYBE change if we rename
 )
 for file in ${FILES_TO_CHECK[@]}; do
   if [[ ! -e $file ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -159,7 +159,7 @@ FILES_TO_CHECK=(
   "anat/${SUBJECT}_acq-MTon_MTS_seg.nii.gz"
   "anat/${SUBJECT}_T2star_seg.nii.gz"
   "anat/${SUBJECT}_T2star_gmseg.nii.gz"
-  "dwi${SUBJECT}_rec-average_dwi_seg.nii.gz"
+  "dwi/${SUBJECT}_rec-average_dwi_seg.nii.gz"
 )
 for file in ${FILES_TO_CHECK[@]}; do
   if [[ ! -e $file ]]; then

--- a/process_data.sh
+++ b/process_data.sh
@@ -127,9 +127,8 @@ file_mtoff="${SUBJECT}_acq-MToff_MTS"
 
 if [[ -e "${file_t1w}.nii.gz" && -e "${file_mton}.nii.gz" && -e "${file_mtoff}.nii.gz" ]]; then 
   # Segment spinal cord (only if it does not exist)
-  segment_if_does_not_exist $file_t1w "t1" # Do we keep it or not?
-  segment_if_does_not_exist $file_mton "t2s" # or T2
-  #segment_if_does_not_exist $file_mtoff "t1" # or DWI or t1 = NO --> automatic segmentation doesn't work with sct_deepseg_sc
+  segment_if_does_not_exist $file_t1w "t1" 
+  segment_if_does_not_exist $file_mton "t2s"
  
 else
   echo "WARNING: MTS dataset is incomplete."
@@ -160,7 +159,7 @@ else
   FILE_DWI="${file_dwi}"
 fi
 
-file_dwi_mean="${FILE_DWI}_moco_dwi_mean"
+file_dwi_mean="${FILE_DWI}_moco_dwi_mean" # TO RENAME
 
 # Segment spinal cord (only if it does not exist)
 segment_if_does_not_exist ${file_dwi_mean} "dwi"
@@ -173,9 +172,8 @@ cd ..
 FILES_TO_CHECK=(
   "anat/${SUBJECT}_T1w_seg.nii.gz"
   "anat/${SUBJECT}_T2w_seg.nii.gz"
-  "anat/${SUBJECT}_acq-T1w_MTS_seg.nii.gz" # Maybe remove
+  "anat/${SUBJECT}_acq-T1w_MTS_seg.nii.gz"
   "anat/${SUBJECT}_acq-MTon_MTS_seg.nii.gz"
-  "anat/${SUBJECT}_acq-MToff_MTS_seg.nii.gz" # Maybe remove --> automatic seg fails
   "anat/${SUBJECT}_T2star_seg.nii.gz"
   "anat/${SUBJECT}_T2star_gmseg.nii.gz"
   "dwi/${FILE_DWI}_moco_dwi_mean_seg.nii.gz" # MAYBE change if we rename

--- a/process_data.sh
+++ b/process_data.sh
@@ -123,7 +123,6 @@ segment_if_does_not_exist $file_t2 "t2"
 # ------------------------------------------------------------------------------
 file_t1w="${SUBJECT}_acq-T1w_MTS"
 file_mton="${SUBJECT}_acq-MTon_MTS"
-file_mtoff="${SUBJECT}_acq-MToff_MTS"
 
 if [[ -e "${file_t1w}.nii.gz" && -e "${file_mton}.nii.gz" && -e "${file_mtoff}.nii.gz" ]]; then 
   # Segment spinal cord (only if it does not exist)


### PR DESCRIPTION
### ⚠️ DO NOT MERGE:  preprocessing and processing will be done on this branch

## Context
Related with [issue #90](https://github.com/spine-generic/data-multi-subject/issues/90).
The purpose of this PR is to generate a processed dataset of [spine-generic/data-multi-subject](https://github.com/spine-generic/data-multi-subject) using `preprocess_data.sh` and generate SC and GM segmentations with `process_data.sh`.
## Description
This PR includes:
* `process_data.sh` is seperated in 2 scripts --> `preprocess_data.sh` and `process_data.sh`
* Only segmentation is done in `process_data.sh`, all other processing steps are removed.
* Segmentation is also done for T2* and MTS data.
* `curate_derivatives_spine_generic.py` : curates the derivatives from spine-generic/data-multi-subject

## `preprocess_data.sh`
Preprocessing steps are:
For T1w and T2w :
* Resampling
* Reorient to RPI
* Remove suffix _RPI_r

For T2star:
* Compute root-mean square across 4th dimension (if it exists)
* Remove suffix _rms

For DWI:
* Generate mean image after motion correction
* Remove intermidiate files


### Questions:
* Do we need preprocessing on MTS data?
* Since SC segmentation was computed on mean image after motion correction for dwi, I kept it that way, and the mean image would be in the `spine-generic-processed dataset`, is that ok?

## `process_data.sh`
SC segmentation is performed on T1, T2. T2*, T1w_MTS, MTon_MTS and dwi
### Questions:
* Automatic segmentation fails on MToff_MTS data, I also tried with sct_propseg and it works better, but would require a lot of manual corrections. I would remove it.
* Do we keep T1w_MTS since we already have T1w contrast? (I would keep it, better to have more segmentations)

##  `curate_derivatives_spine_generic.py`
* Gets derivatives with suffix `_seg-manual`
* Removes suffix `_RPI_r` or `_rms`
* Creates a json sidecar if it does not exist
* Reorient and resamples `_csgseg-manual.nii.gz` images
