### PR TITLE
add ucdavis flag into spinegeneric/cli/generate_figure.py

### DIFF
--- a/spinegeneric/cli/generate_figure.py
+++ b/spinegeneric/cli/generate_figure.py
@@ -103,6 +103,7 @@ flags = {
     'tokyoIngenia': 'japan',
     'ubc': 'canada',
     'ucl': 'uk',
+    'ucdavis': 'us',
     'unf': 'canada',
     'vallHebron': 'spain',
     'vuiisAchieva': 'us',


### PR DESCRIPTION
I have tried sg_generate_figure with acdavis flag extension and the graph generator worked fine and exported all figures as shown in Sci Data paper, only extended about VIDA ucdavis scanner.
Magnetization transfer for ucdavis appears off, comapred to other Siemens results.