### PR TITLE
Update skimage to the latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sklearn
 statsmodels
 pyyaml
 pybids~=0.13.0 # pinned until https://github.com/bids-standard/pybids/pull/791 is fixed
-scikit-image~=0.17.2
+scikit-image
 transforms3d~=0.3.1
 pandas-schema
 plotly~=4.12.0


### PR DESCRIPTION
skimage 0.17 does not have wheels built for python 3.9 or python 3.10 because they didn't exist when it was published, meaning anyone who tries to use spine-generic on a modern system (even just Ubuntu 22.04 LTS) will find themselves in a surprise compilation mire.