### PR TITLE
Move flake8 configuration into .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+
+# This constrains how dense the code of each function can be
+max-complexity = 10
+
+# The GitHub editor is 127 chars wide
+max-line-length = 127 
+
+count = true
+statistics = true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,4 @@ jobs:
     - name: Install flake8
       run: pip install flake8
     - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      run: flake8


### PR DESCRIPTION
It is easier (and more conventional) to maintain.

Also, make lint.yml treat all flake warnings as errors, not just syntax problems. Previously, the linter had been turned down so that only four errors were actually errors, and the rest got --exit-zero, presumably to triage problems, but the time I found it both had been entirely disabled. I separated linting to a separate Action which I made non-mandatory, achieving the same effect, so now I think we can shorten the script to just run the full linter in the conventional way.

And if we can get the lint back under control then we can make it mandatory again.