### PR TITLE
Clean up `sg_params_checker` so it can be run on `data-multi-subject` without crashing

### DIFF
--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -84,8 +84,6 @@ def main():
             logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
             continue
 
-        if "SoftwareVersions" in item.get_metadata():
-            SoftwareVersions = item.get_metadata()["SoftwareVersions"]
         Contrast = ((item.filename).split("_")[-1]).split(".")[0]
         if Contrast == "MTS":
             MTS_acq = item.filename.split("_acq-")[1].split(".")[0]

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -73,85 +73,86 @@ def main():
     for item in query:
         if "Manufacturer" not in item.get_metadata():
             logging.warning(f" {item.filename}: Missing Manufacturer in json sidecar; Cannot check parameters.")
-        else:
-            Manufacturer = item.get_metadata()["Manufacturer"]
-            if Manufacturer not in data.keys():
-                logging.warning(f" {item.filename}: Manufacturer '{Manufacturer}' not in list "
-                                f"of known manufacturers: {data.keys()}. Cannot check parameters.")
-            else:
-                ManufacturersModelName = item.get_metadata()["ManufacturersModelName"]
-                if ManufacturersModelName not in data[Manufacturer].keys():
-                    logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
-                else:
-                    if "SoftwareVersions" in item.get_metadata():
-                        SoftwareVersions = item.get_metadata()["SoftwareVersions"]
-                    RepetitionTime = item.get_metadata()["RepetitionTime"]
-                    Contrast = ((item.filename).split("_")[-1]).split(".")[0]
-                    if Contrast == "MTS":
-                        MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
-                        Contrast = MTS_acq
-                    keys_contrast = data[Manufacturer][ManufacturersModelName][
-                        str(Contrast)
-                    ].keys()
-                    if "RepetitionTime" in keys_contrast:
-                        if (
-                            RepetitionTime
-                            - data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                                "RepetitionTime"
-                            ]
-                        ) > 0.1:
-                            logging.warning(
-                                " "
-                                + item.filename
-                                + ": Incorrect RepetitionTime: TR="
-                                + str(RepetitionTime)
-                                + " instead of "
-                                + str(
-                                    data[Manufacturer][ManufacturersModelName][
-                                        str(Contrast)
-                                    ]["RepetitionTime"]
-                                )
-                            )
-                    EchoTime = item.get_metadata()["EchoTime"]
-                    if "EchoTime" in keys_contrast:
-                        if (
-                            EchoTime
-                            - data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                                "EchoTime"
-                            ]
-                        ) > 0.1:
-                            logging.warning(
-                                " "
-                                + item.filename
-                                + ": Incorrect EchoTime: TE="
-                                + str(EchoTime)
-                                + " instead of "
-                                + str(
-                                    data[Manufacturer][ManufacturersModelName][
-                                        str(Contrast)
-                                    ]["EchoTime"]
-                                )
-                            )
-                    FlipAngle = item.get_metadata()["FlipAngle"]
-                    if "FlipAngle" in keys_contrast:
-                        if (
-                            data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                                "FlipAngle"
-                            ]
-                            != FlipAngle
-                        ):
-                            logging.warning(
-                                " "
-                                + item.filename
-                                + ": Incorrect FlipAngle: FA="
-                                + str(FlipAngle)
-                                + " instead of "
-                                + str(
-                                    data[Manufacturer][ManufacturersModelName][
-                                        str(Contrast)
-                                    ]["FlipAngle"]
-                                )
-                            )
+            continue
+        Manufacturer = item.get_metadata()["Manufacturer"]
+        if Manufacturer not in data.keys():
+            logging.warning(f" {item.filename}: Manufacturer '{Manufacturer}' not in list "
+                            f"of known manufacturers: {data.keys()}. Cannot check parameters.")
+            continue
+        ManufacturersModelName = item.get_metadata()["ManufacturersModelName"]
+        if ManufacturersModelName not in data[Manufacturer].keys():
+            logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
+            continue
+
+        if "SoftwareVersions" in item.get_metadata():
+            SoftwareVersions = item.get_metadata()["SoftwareVersions"]
+        RepetitionTime = item.get_metadata()["RepetitionTime"]
+        Contrast = ((item.filename).split("_")[-1]).split(".")[0]
+        if Contrast == "MTS":
+            MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
+            Contrast = MTS_acq
+        keys_contrast = data[Manufacturer][ManufacturersModelName][
+            str(Contrast)
+        ].keys()
+        if "RepetitionTime" in keys_contrast:
+            if (
+                RepetitionTime
+                - data[Manufacturer][ManufacturersModelName][str(Contrast)][
+                    "RepetitionTime"
+                ]
+            ) > 0.1:
+                logging.warning(
+                    " "
+                    + item.filename
+                    + ": Incorrect RepetitionTime: TR="
+                    + str(RepetitionTime)
+                    + " instead of "
+                    + str(
+                        data[Manufacturer][ManufacturersModelName][
+                            str(Contrast)
+                        ]["RepetitionTime"]
+                    )
+                )
+        EchoTime = item.get_metadata()["EchoTime"]
+        if "EchoTime" in keys_contrast:
+            if (
+                EchoTime
+                - data[Manufacturer][ManufacturersModelName][str(Contrast)][
+                    "EchoTime"
+                ]
+            ) > 0.1:
+                logging.warning(
+                    " "
+                    + item.filename
+                    + ": Incorrect EchoTime: TE="
+                    + str(EchoTime)
+                    + " instead of "
+                    + str(
+                        data[Manufacturer][ManufacturersModelName][
+                            str(Contrast)
+                        ]["EchoTime"]
+                    )
+                )
+        FlipAngle = item.get_metadata()["FlipAngle"]
+        if "FlipAngle" in keys_contrast:
+            if (
+                data[Manufacturer][ManufacturersModelName][str(Contrast)][
+                    "FlipAngle"
+                ]
+                != FlipAngle
+            ):
+                logging.warning(
+                    " "
+                    + item.filename
+                    + ": Incorrect FlipAngle: FA="
+                    + str(FlipAngle)
+                    + " instead of "
+                    + str(
+                        data[Manufacturer][ManufacturersModelName][
+                            str(Contrast)
+                        ]["FlipAngle"]
+                    )
+                )
 
     # Print WARNING log
     if path_warning_log:

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -38,11 +38,9 @@ def get_parser():
 
 
 def main():
-
     # Parse input arguments
     parser = get_parser()
     args = parser.parse_args()
-
     data_path = args.path_in
 
     path_warning_log = os.path.join(data_path, "WARNING.log")

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -86,7 +86,6 @@ def main():
 
         if "SoftwareVersions" in item.get_metadata():
             SoftwareVersions = item.get_metadata()["SoftwareVersions"]
-        RepetitionTime = item.get_metadata()["RepetitionTime"]
         Contrast = ((item.filename).split("_")[-1]).split(".")[0]
         if Contrast == "MTS":
             MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
@@ -94,25 +93,15 @@ def main():
         keys_contrast = data[Manufacturer][ManufacturersModelName][
             str(Contrast)
         ].keys()
+
+        # Validate repetition time against manufacturer's specifications
+        RepetitionTime = item.get_metadata()["RepetitionTime"]
         if "RepetitionTime" in keys_contrast:
-            if (
-                RepetitionTime
-                - data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                    "RepetitionTime"
-                ]
-            ) > 0.1:
-                logging.warning(
-                    " "
-                    + item.filename
-                    + ": Incorrect RepetitionTime: TR="
-                    + str(RepetitionTime)
-                    + " instead of "
-                    + str(
-                        data[Manufacturer][ManufacturersModelName][
-                            str(Contrast)
-                        ]["RepetitionTime"]
-                    )
-                )
+            ExpectedRT = data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]
+            if RepetitionTime - ExpectedRT > 0.1:
+                logging.warning(f" {item.filename}: Incorrect RepetitionTime: "
+                                f"TR={RepetitionTime} instead of {ExpectedRT}.")
+
         EchoTime = item.get_metadata()["EchoTime"]
         if "EchoTime" in keys_contrast:
             if (

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -110,26 +110,13 @@ def main():
                 logging.warning(f" {item.filename}: Incorrect EchoTime: "
                                 f"TE={EchoTime} instead of {ExpectedTE}.")
 
+        # Validate flip angle against manufacturer's specifications
         FlipAngle = item.get_metadata()["FlipAngle"]
         if "FlipAngle" in keys_contrast:
-            if (
-                data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                    "FlipAngle"
-                ]
-                != FlipAngle
-            ):
-                logging.warning(
-                    " "
-                    + item.filename
-                    + ": Incorrect FlipAngle: FA="
-                    + str(FlipAngle)
-                    + " instead of "
-                    + str(
-                        data[Manufacturer][ManufacturersModelName][
-                            str(Contrast)
-                        ]["FlipAngle"]
-                    )
-                )
+            ExpectedFA = data[Manufacturer][ManufacturersModelName][str(Contrast)]["FlipAngle"]
+            if FlipAngle != ExpectedFA:
+                logging.warning(f" {item.filename}: Incorrect FlipAngle: "
+                                f"FA={FlipAngle} instead of {ExpectedFA}.")
 
     # Print WARNING log
     if path_warning_log:

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -85,9 +85,7 @@ def main():
         if Contrast == "MTS":
             MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
             Contrast = MTS_acq
-        keys_contrast = data[Manufacturer][ManufacturersModelName][
-            str(Contrast)
-        ].keys()
+        keys_contrast = data[Manufacturer][ManufacturersModelName][str(Contrast)].keys()
 
         # Validate repetition time against manufacturer's specifications
         RepetitionTime = item.get_metadata()["RepetitionTime"]

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -102,26 +102,14 @@ def main():
                 logging.warning(f" {item.filename}: Incorrect RepetitionTime: "
                                 f"TR={RepetitionTime} instead of {ExpectedRT}.")
 
+        # Validate echo time against manufacturer's specifications
         EchoTime = item.get_metadata()["EchoTime"]
         if "EchoTime" in keys_contrast:
-            if (
-                EchoTime
-                - data[Manufacturer][ManufacturersModelName][str(Contrast)][
-                    "EchoTime"
-                ]
-            ) > 0.1:
-                logging.warning(
-                    " "
-                    + item.filename
-                    + ": Incorrect EchoTime: TE="
-                    + str(EchoTime)
-                    + " instead of "
-                    + str(
-                        data[Manufacturer][ManufacturersModelName][
-                            str(Contrast)
-                        ]["EchoTime"]
-                    )
-                )
+            ExpectedTE = data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]
+            if EchoTime - ExpectedTE > 0.1:
+                logging.warning(f" {item.filename}: Incorrect EchoTime: "
+                                f"TE={EchoTime} instead of {ExpectedTE}.")
+
         FlipAngle = item.get_metadata()["FlipAngle"]
         if "FlipAngle" in keys_contrast:
             if (

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -71,14 +71,18 @@ def main():
 
     # Loop across the contrast images to check parameters
     for item in query:
-        if "Manufacturer" in item.get_metadata():
+        if "Manufacturer" not in item.get_metadata():
+            logging.warning(f" {item.filename}: Missing Manufacturer in json sidecar; Cannot check parameters.")
+        else:
             Manufacturer = item.get_metadata()["Manufacturer"]
             if Manufacturer not in data.keys():
                 logging.warning(f" {item.filename}: Manufacturer '{Manufacturer}' not in list "
                                 f"of known manufacturers: {data.keys()}. Cannot check parameters.")
             else:
                 ManufacturersModelName = item.get_metadata()["ManufacturersModelName"]
-                if ManufacturersModelName in data[Manufacturer].keys():
+                if ManufacturersModelName not in data[Manufacturer].keys():
+                    logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
+                else:
                     if "SoftwareVersions" in item.get_metadata():
                         SoftwareVersions = item.get_metadata()["SoftwareVersions"]
                     RepetitionTime = item.get_metadata()["RepetitionTime"]
@@ -148,20 +152,6 @@ def main():
                                     ]["FlipAngle"]
                                 )
                             )
-                else:
-                    logging.warning(
-                        " "
-                        + item.filename
-                        + ": Missing: "
-                        + ManufacturersModelName
-                        + "; Cannot check parameters."
-                    )
-        else:
-            logging.warning(
-                " "
-                + item.filename
-                + ": Missing Manufacturer in json sidecar; Cannot check parameters."
-            )
 
     # Print WARNING log
     if path_warning_log:

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -114,8 +114,13 @@ def main():
             #       data-multi-subject, but may fail for "T1w_MTS" data, if such data even exists?
             try:
                 # Try new method for renamed, BIDS-compliant 'data-multi-subject'
-                MTS_acq = item.filename.split('_')[-2]
-                Contrast = {'mt-off': "MToff_MTS", 'mt-on': "MTon_MTS"}[MTS_acq]
+                MTS_type = "_".join(item.filename.split('_')[-3:-1])
+                type_to_contrast = {
+                    "flip-1_mt-off": "MToff_MTS",
+                    "flip-1_mt-on":  "MTon_MTS",
+                    "flip-2_mt-off": "T1w_MTS"
+                }
+                Contrast = type_to_contrast[MTS_type]
             except KeyError:
                 # Fall back to the old method for backwards compatibility with older datasets
                 Contrast = item.filename.split("_acq-")[1].split(".")[0]

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -127,7 +127,7 @@ def main():
         RepetitionTime = item.get_metadata()["RepetitionTime"]
         if "RepetitionTime" in keys_contrast:
             ExpectedRT = data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]
-            # TODO: We check against at threshold here, rather than FA, which checks for exactness. Do we want this?
+            # TODO: We only check `val > 0.1`, rather than `abs(val) > 0.1`. Is this a bug?
             if RepetitionTime - ExpectedRT > 0.1:
                 logging.warning(f" {item.filename}: Incorrect RepetitionTime: "
                                 f"TR={RepetitionTime} instead of {ExpectedRT} +/- 0.1.")
@@ -136,7 +136,7 @@ def main():
         EchoTime = item.get_metadata()["EchoTime"]
         if "EchoTime" in keys_contrast:
             ExpectedTE = data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]
-            # TODO: We check against at threshold here, rather than FA, which checks for exactness. Do we want this?
+            # TODO: We only check `val > 0.1`, rather than `abs(val) > 0.1`. Is this a bug?
             if EchoTime - ExpectedTE > 0.1:
                 logging.warning(f" {item.filename}: Incorrect EchoTime: "
                                 f"TE={EchoTime} instead of {ExpectedTE} +/- 0.1.")

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -108,10 +108,6 @@ def main():
         # 'MToff_MTS', 'T1w_MTS' etc. are used. So, we need to parse the type of MTS from the filename,
         # then convert it to the specific names expected by the 'manufacturer params' dictionary.
         if Contrast == "MTS":
-            # TODO: The manufacturer param dicts specifically contains the key "T1w_MTS", but I can't
-            #       find a single file in `data-multi-subject` that is MTS + T1w. Instead, all I see are
-            #       'mt-off' and 'mt-on'. So, this new method for parsing filenames passes for
-            #       data-multi-subject, but may fail for "T1w_MTS" data, if such data even exists?
             try:
                 # Try new method for renamed, BIDS-compliant 'data-multi-subject'
                 MTS_type = "_".join(item.filename.split('_')[-3:-1])

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -22,7 +22,7 @@ import spinegeneric.config
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Acquisition parameters checker feature. This feature allows the users"
+        description="Acquisition parameters checker feature. This feature allows the users "
                     "to compare the acquisition parameters that can be found in the json "
                     "sidecar to the recommended acquisition parameters.",
         formatter_class=sg.utils.SmartFormatter,

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -69,7 +69,7 @@ def main():
     # Loop across the contrast images to check parameters
     for item in query:
         if "Manufacturer" not in item.get_metadata():
-            logging.warning(f" {item.filename}: Missing Manufacturer in json sidecar; Cannot check parameters.")
+            logging.warning(f" {item.filename}: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.")
             continue
         Manufacturer = item.get_metadata()["Manufacturer"]
         if Manufacturer not in data.keys():
@@ -78,7 +78,8 @@ def main():
             continue
         ManufacturersModelName = item.get_metadata()["ManufacturersModelName"]
         if ManufacturersModelName not in data[Manufacturer].keys():
-            logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
+            logging.warning(f" {item.filename}: Model '{ManufacturersModelName}' not present in list of known "
+                            f"models for manufacturer '{Manufacturer}'. Cannot check parameters.")
             continue
 
         Contrast = (item.filename.split("_")[-1]).split(".")[0]
@@ -93,7 +94,7 @@ def main():
             ExpectedRT = data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]
             if RepetitionTime - ExpectedRT > 0.1:
                 logging.warning(f" {item.filename}: Incorrect RepetitionTime: "
-                                f"TR={RepetitionTime} instead of {ExpectedRT}.")
+                                f"TR={RepetitionTime} instead of {ExpectedRT} +/- 0.1.")
 
         # Validate echo time against manufacturer's specifications
         EchoTime = item.get_metadata()["EchoTime"]
@@ -101,7 +102,7 @@ def main():
             ExpectedTE = data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]
             if EchoTime - ExpectedTE > 0.1:
                 logging.warning(f" {item.filename}: Incorrect EchoTime: "
-                                f"TE={EchoTime} instead of {ExpectedTE}.")
+                                f"TE={EchoTime} instead of {ExpectedTE} +/- 0.1.")
 
         # Validate flip angle against manufacturer's specifications
         FlipAngle = item.get_metadata()["FlipAngle"]

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -80,7 +80,7 @@ def main():
     # Fetch a list of `BIDSImageFile` objects from the layout that meet the requirements below
     query = layout.get(suffix=["T1w", "T2w", "T2star", "MTS"], extension="nii.gz")
 
-    # Fetch acquisition parameters from various vendors (Siemens, GE, Phillips) and MRI models
+    # Fetch acquisition parameters for various vendors (Siemens, GE, Phillips) and MRI models
     with importlib.resources.path(spinegeneric.config, "specs.json") as path_specs:
         with open(path_specs) as json_file:
             data = json.load(json_file)  # TODO: We could probably be more descriptive with this filename?
@@ -104,8 +104,8 @@ def main():
 
         # Parse the file's contrast from its suffix (sans `.nii.gz`)
         Contrast = (item.filename.split("_")[-1]).split(".")[0]
-        # In the case of MTS files, manufacturers won't just specify 'MTS'. Instead, 'MTon_MTS',
-        # 'MToff_MTS', 'T1w_MTS' etc. will be used. So, we need to parse the type of MTS from the filename,
+        # In the case of MTS files, the spine-generic protocol doesn't just specify 'MTS'. Instead, 'MTon_MTS',
+        # 'MToff_MTS', 'T1w_MTS' etc. are used. So, we need to parse the type of MTS from the filename,
         # then convert it to the specific names expected by the 'manufacturer params' dictionary.
         if Contrast == "MTS":
             # TODO: The manufacturer param dicts specifically contains the key "T1w_MTS", but I can't
@@ -123,7 +123,7 @@ def main():
         # Fetch the names of each available parameter for the given manufacturer + model
         keys_contrast = data[Manufacturer][ManufacturersModelName][str(Contrast)].keys()
 
-        # Validate repetition time against manufacturer's specifications
+        # Validate repetition time against spine-generic's acquisition protocol
         RepetitionTime = item.get_metadata()["RepetitionTime"]
         if "RepetitionTime" in keys_contrast:
             ExpectedRT = data[Manufacturer][ManufacturersModelName][str(Contrast)]["RepetitionTime"]
@@ -132,7 +132,7 @@ def main():
                 logging.warning(f" {item.filename}: Incorrect RepetitionTime: "
                                 f"TR={RepetitionTime} instead of {ExpectedRT} +/- 0.1.")
 
-        # Validate echo time against manufacturer's specifications
+        # Validate echo time against spine-generic's acquisition protocol
         EchoTime = item.get_metadata()["EchoTime"]
         if "EchoTime" in keys_contrast:
             ExpectedTE = data[Manufacturer][ManufacturersModelName][str(Contrast)]["EchoTime"]
@@ -141,7 +141,7 @@ def main():
                 logging.warning(f" {item.filename}: Incorrect EchoTime: "
                                 f"TE={EchoTime} instead of {ExpectedTE} +/- 0.1.")
 
-        # Validate flip angle against manufacturer's specifications
+        # Validate flip angle against spine-generic's acquisition protocol
         FlipAngle = item.get_metadata()["FlipAngle"]
         if "FlipAngle" in keys_contrast:
             ExpectedFA = data[Manufacturer][ManufacturersModelName][str(Contrast)]["FlipAngle"]

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -22,7 +22,7 @@ import spinegeneric.config
 
 def get_parser():
     parser = argparse.ArgumentParser(
-        description="Acquistion parameters checker feature. This feature allows the users"
+        description="Acquisition parameters checker feature. This feature allows the users"
         "to compare the acquisition parameters that can be found in the json "
         "sidecar to the recommended acquisition parameters.",
         formatter_class=sg.utils.SmartFormatter,

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -100,10 +100,16 @@ def main():
         # Parse the file's contrast from its suffix (sans `.nii.gz`)
         Contrast = (item.filename.split("_")[-1]).split(".")[0]
         # In the case of MTS files, manufacturers won't just specify 'MTS'. Instead, 'MTon_MTS',
-        # 'MToff_MTS', 'T1w_MTS' etc. will be used. So, we need to parse the type of MTS from the filename.
+        # 'MToff_MTS', 'T1w_MTS' etc. will be used. So, we need to parse the type of MTS from the filename,
+        # then convert it to the specific names expected by the 'manufacturer params' dictionary.
         if Contrast == "MTS":
-            MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
-            Contrast = MTS_acq
+            try:
+                # Try new method for renamed, BIDS-compliant 'data-multi-subject'
+                MTS_acq = item.filename.split('_')[-2]
+                Contrast = {'mt-off': "MToff_MTS", 'mt-on': "MTon_MTS"}[MTS_acq]
+            except KeyError:
+                # Fall back to the old method for backwards compatibility with older datasets
+                Contrast = item.filename.split("_acq-")[1].split(".")[0]
 
         # Fetch the names of each available parameter for the given manufacturer + model
         keys_contrast = data[Manufacturer][ManufacturersModelName][str(Contrast)].keys()

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -55,9 +55,7 @@ def main():
     )
 
     # Initialize the layout
-    with importlib.resources.path(
-        spinegeneric.config, "bids_specs.json"
-    ) as path_sg_layout_config:
+    with importlib.resources.path(spinegeneric.config, "bids_specs.json") as path_sg_layout_config:
         layout = BIDSLayout(
             data_path,
             indexer=BIDSLayoutIndexer(config_filename=path_sg_layout_config),

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -60,8 +60,7 @@ def main():
             validate=False,
         )
 
-    Contrast_list = ["T1w", "T2w", "T2star", "MTS"]
-    query = layout.get(suffix=Contrast_list, extension="nii.gz")
+    query = layout.get(suffix=["T1w", "T2w", "T2star", "MTS"], extension="nii.gz")
 
     with importlib.resources.path(spinegeneric.config, "specs.json") as path_specs:
         with open(path_specs) as json_file:

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -84,7 +84,7 @@ def main():
             logging.warning(f" {item.filename}: Missing: {ManufacturersModelName}; Cannot check parameters.")
             continue
 
-        Contrast = ((item.filename).split("_")[-1]).split(".")[0]
+        Contrast = (item.filename.split("_")[-1]).split(".")[0]
         if Contrast == "MTS":
             MTS_acq = item.filename.split("_acq-")[1].split(".")[0]
             Contrast = MTS_acq

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -73,7 +73,10 @@ def main():
     for item in query:
         if "Manufacturer" in item.get_metadata():
             Manufacturer = item.get_metadata()["Manufacturer"]
-            if Manufacturer in data.keys():
+            if Manufacturer not in data.keys():
+                logging.warning(f" {item.filename}: Manufacturer '{Manufacturer}' not in list "
+                                f"of known manufacturers: {data.keys()}. Cannot check parameters.")
+            else:
                 ManufacturersModelName = item.get_metadata()["ManufacturersModelName"]
                 if ManufacturersModelName in data[Manufacturer].keys():
                     if "SoftwareVersions" in item.get_metadata():

--- a/spinegeneric/cli/params_checker.py
+++ b/spinegeneric/cli/params_checker.py
@@ -23,8 +23,8 @@ import spinegeneric.config
 def get_parser():
     parser = argparse.ArgumentParser(
         description="Acquisition parameters checker feature. This feature allows the users"
-        "to compare the acquisition parameters that can be found in the json "
-        "sidecar to the recommended acquisition parameters.",
+                    "to compare the acquisition parameters that can be found in the json "
+                    "sidecar to the recommended acquisition parameters.",
         formatter_class=sg.utils.SmartFormatter,
         prog=os.path.basename(__file__).strip(".py"),
     )


### PR DESCRIPTION
## Description

This PR has 3 parts:

- The first 16 commits are refactoring commits to make the script clearer and more concise. They clean up the code style of the script, while also adding documentation to make certain aspects (`BIDSLayout`, `BIDSLayoutIndexer`) easier to understand.
- The second to last commit, dc73e639e714ce4c64286b1b013d92386a797954, fixes #264.
- The last commit, 4adaeb7f09dfe5e66a2cb940a25ceccf1a4a88a4, adds some TODOs for discussion in this PR. 

Running the script on `data-multi-subject` results in 142 warnings:

<details>

```
WARNING: sub-amu01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-amu01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-amu02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-amu02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-amu03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-amu03_T2w.nii.gz: Incorrect FlipAngle: FA=135 instead of 120.
WARNING: sub-amu04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-amu04_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-amu05_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-amu05_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-beijingVerio01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-beijingVerio01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-beijingVerio02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-beijingVerio02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-beijingVerio03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-beijingVerio03_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-beijingVerio04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-beijingVerio04_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-nottwil01_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil01_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil02_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil03_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil04_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil05_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-nottwil06_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-strasbourg01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-strasbourg01_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-strasbourg02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-strasbourg02_T2w.nii.gz: Incorrect FlipAngle: FA=180 instead of 120.
WARNING: sub-ucdavis01_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis01_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis01_flip-2_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis01_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis01_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis01_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_flip-2_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis02_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis03_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis03_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis03_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis03_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis03_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_flip-2_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis04_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis05_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis05_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis05_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis05_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis05_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis06_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis06_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis06_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis06_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis06_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis07_flip-1_mt-off_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis07_flip-1_mt-on_MTS.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis07_T1w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis07_T2star.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucdavis07_T2w.nii.gz: Model 'MAGNETOM Vida' not present in list of known models for manufacturer 'Siemens'. Cannot check parameters.
WARNING: sub-ucl01_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl01_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl02_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl03_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl04_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl05_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_flip-1_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_flip-1_mt-on_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_flip-2_mt-off_MTS.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T1w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T2star.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-ucl06_T2w.nii.gz: Missing 'Manufacturer' key in json sidecar; Cannot check parameters.
WARNING: sub-vallHebron01_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron01_T2w.nii.gz: Incorrect FlipAngle: FA=170 instead of 180.
WARNING: sub-vallHebron02_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron03_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron04_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron04_T2w.nii.gz: Incorrect FlipAngle: FA=165 instead of 180.
WARNING: sub-vallHebron05_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron06_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron07_T2w.nii.gz: Incorrect RepetitionTime: TR=2 instead of 1.5 +/- 0.1.
WARNING: sub-vallHebron07_T2w.nii.gz: Incorrect FlipAngle: FA=150 instead of 180.
```
</details>

## Reviewing this PR.

I hope the refactoring commits aren't too much of a bother; I've tried my best to keep them clear and atomic. So, I'd recommend using the "Commits" view to review each change in isolation.

##  Related issues

Fixes #264.