### PR TITLE
Documentation - Rename MTS suffix

### DIFF
--- a/docs/analysis-pipeline.rst
+++ b/docs/analysis-pipeline.rst
@@ -8,10 +8,10 @@ MRI data and output the following metrics for each contrast:
 -  **T2**: Spinal cord CSA averaged between C2 and C3.
 -  **T2s**: Gray matter CSA averaged between C3 and C4.
 -  **DWI**: FA in WM averaged between C2 and C5.
--  **MTS**: MTR in WM averaged between C2 and C5. Uses MTon\_MTS and
-   MToff\_MTS.
+-  **MTS**: MTR in WM averaged between C2 and C5. Uses flip-1\_mt-on\_MTS and
+   flip-1\_mt-off\_MTS.
 -  **MTS**: MTSat & T1 map in WM averaged between C2 and C5. Uses
-   MTon\_MTS, MToff\_MTS and T1w\_MTS.
+   flip-1\_mt-on\_MTS, flip-1\_mt-off\_MTS and flip-2\_mt-off\_MTS.
 
 
 Dependencies
@@ -122,7 +122,7 @@ Some explanations about this yml file:
 +-------------------------------------------------------+---------------------------------------------------+-----------------+-----------------------+
 | sub-XX\_T2star\_rms\_gmseg.nii.gz                     | sub-XX\_T2star\_rms.nii.gz                        | C3-C4           | CSA                   |
 +-------------------------------------------------------+---------------------------------------------------+-----------------+-----------------------+
-| sub-XX\_acq-T1w\_MTS\_seg.nii.gz                      | sub-XX\_acq-T1w\_MTS.nii.gz                       | C2-C5           | Template registration |
+| sub-XX\_flip-2\_mt-off\_MTS\_seg.nii.gz                      | sub-XX\_flip-2\_mt-off\_MTS.nii.gz                       | C2-C5           | Template registration |
 +-------------------------------------------------------+---------------------------------------------------+-----------------+-----------------------+
 | sub-XX\_dwi\_concat\_crop\_moco\_dwi\_mean_seg.nii.gz | sub-XX\_dwi\_concat\_crop\_moco\_dwi\_mean.nii.gz | C2-C5           | Template registration |
 +-------------------------------------------------------+---------------------------------------------------+-----------------+-----------------------+
@@ -201,7 +201,7 @@ To generate a mosaic of images, run:
   # Sagittal views of 3D T1w data
   sg_create_mosaic -i *T1w_RPI_r_flatten.nii.gz -ifolder ~/project/results_multi_20200907/data_processed/ -p sag -col 20 -row 13 -o fig_mosaic_T1w.png
   # Axial views of GRE-T1w data
-  sg_create_mosaic -i *acq-T1w_MTS.nii.gz -ifolder ~/spineGeneric_results/data_processed -s _seg -p ax -col 20 -row 13 -o fig_mosaic_GRE-T1w.png
+  sg_create_mosaic -i *flip-2_mt-off_MTS.nii.gz -ifolder ~/spineGeneric_results/data_processed -s _seg -p ax -col 20 -row 13 -o fig_mosaic_GRE-T1w.png
 
 Results
 -------

--- a/docs/data-acquisition.rst
+++ b/docs/data-acquisition.rst
@@ -51,12 +51,12 @@ structure for one center is shown below:
     │   │   ├── sub-ubc06_T2star.nii.gz
     │   │   ├── sub-ubc06_T2w.json
     │   │   ├── sub-ubc06_T2w.nii.gz
-    │   │   ├── sub-ubc06_acq-MToff_MTS.json
-    │   │   ├── sub-ubc06_acq-MToff_MTS.nii.gz
-    │   │   ├── sub-ubc06_acq-MTon_MTS.json
-    │   │   ├── sub-ubc06_acq-MTon_MTS.nii.gz
-    │   │   ├── sub-ubc06_acq-T1w_MTS.json
-    │   │   └── sub-ubc06_acq-T1w_MTS.nii.gz
+    │   │   ├── sub-ubc06_flip-1_mt-off_MTS.json
+    │   │   ├── sub-ubc06_flip-1_mt-off_MTS.nii.gz
+    │   │   ├── sub-ubc06_flip-1_mt-on_MTS.json
+    │   │   ├── sub-ubc06_flip-1_mt-on_MTS.nii.gz
+    │   │   ├── sub-ubc06_flip-2_mt-off_MTS.json
+    │   │   └── sub-ubc06_flip-2_mt-off_MTS.nii.gz
     │   │
     │   └── dwi
     │       ├── sub-ubc06_dwi.bval
@@ -78,8 +78,8 @@ structure for one center is shown below:
                 │   ├── sub-ubc06_T1w_RPI_r_labels-manual.json
                 │   ├── sub-ubc06_T2w_RPI_r_seg-manual.nii.gz  <---------- manually-corrected spinal cord segmentation
                 │   ├── sub-ubc06_T2w_RPI_r_seg-manual.json
-                │   ├── sub-ubc06_acq-T1w_MTS_seg-manual.nii.gz  <-------- manually-corrected spinal cord segmentation
-                │   ├── sub-ubc06_acq-T1w_MTS_seg-manual.json
+                │   ├── sub-ubc06_flip-2_mt-off_MTS_seg-manual.nii.gz  <-------- manually-corrected spinal cord segmentation
+                │   ├── sub-ubc06_flip-2_mt-off_MTS_seg-manual.json
                 │   ├── sub-ubc06_T2star_rms_gmseg-manual.nii.gz  <------- manually-corrected gray matter segmentation
                 │   └── sub-ubc06_T2star_rms_gmseg-manual.json
                 │

--- a/docs/data-acquisition.rst
+++ b/docs/data-acquisition.rst
@@ -294,19 +294,19 @@ Example of datasets
 
     <iframe src="_static/sub-brnoCeitec01_T2star.html"  width=800 height=300 style="padding:0; border:0; display: block; margin-left: auto; margin-right: auto"></iframe>
 
-**MTon_MTS - sub-barcelona04**
+**flip-1_mt-on_MTS - sub-barcelona04**
 
 .. raw:: html
 
     <iframe src="_static/sub-barcelona04_acq-MTon_MTS.html"  width=800 height=400 style="padding:0; border:0; display: block; margin-left: auto; margin-right: auto"></iframe>
 
-**MToff_MTS - sub-barcelona04**
+**flip-1_mt-off_MTS - sub-barcelona04**
 
 .. raw:: html
 
     <iframe src="_static/sub-barcelona04_acq-MToff_MTS.html" width=800 height=400 style="padding:0; border:0; display: block; margin-left: auto; margin-right: auto"></iframe>
 
-**T1w_MTS - sub-barcelona04**
+**flip-2_mt-off_MTS - sub-barcelona04**
 
 .. raw:: html
 


### PR DESCRIPTION
Rename MTS suffix to be in line with https://github.com/spine-generic/data-multi-subject/pull/135


```
acq-MTon_MTS → flip-1_mt-on_MTS
acq-MToff_MTS → flip-1_mt-off_MTS
acq-T1w_MTS → flip-2_mt-off_MTS
```