### PR TITLE
Specify sphinx-rtd-theme as a dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ version = importlib.metadata.version("spinegeneric")
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ transforms3d~=0.3.1
 pandas-schema
 plotly~=4.12.0
 opencv-python
+sphinx-rtd-theme~=3.0.1


### PR DESCRIPTION
The ReadTheDocs page has been failing to build for the past year:

https://readthedocs.org/projects/spine-generic/builds/

Looking at the logs, it looks like this is because of a missing dependency in `requirements.txt` for the ReadTheDocs theme. According to the theme documentation for the latest version (3.0.1), it looks like the theme needs to be pip installed, and activated as an extension, and they recommend pinning the version:

https://sphinx-rtd-theme.readthedocs.io/en/3.0.1/installing.html