### PR TITLE
Update supported Python versions to `">=3.9"`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/docs/analysis-pipeline.rst
+++ b/docs/analysis-pipeline.rst
@@ -20,7 +20,7 @@ Dependencies
 MANDATORY:
 
 - For processing: `SCT 5.0.1 <https://github.com/neuropoly/spinalcordtoolbox/releases/tag/5.0.1>`__.
-- For generating figures: Python >= 3.7
+- For generating figures: Python >= 3.9
 
 OPTIONAL:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ statsmodels
 pyyaml
 pybids
 scikit-image
-transforms3d~=0.3.1
+transforms3d
 pandas-schema
 plotly~=4.12.0
 opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ statsmodels
 pyyaml
 pybids
 scikit-image
-transforms3d
 pandas-schema
 plotly~=4.12.0
 opencv-python

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(req_path, "r") as f:
 setup(
     name="spinegeneric",
     version=spinegeneric.__version__,
-    python_requires=">=3.7,<3.12",
+    python_requires=">=3.9,<=3.13",
     description="Collection of cli to process data for the Spine Generic project.",
     url="https://spine-generic.rtfd.io",
     author="NeuroPoly Lab, Polytechnique Montreal",
@@ -27,11 +27,12 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+
     ],
     keywords="",
     install_requires=install_reqs,

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(req_path, "r") as f:
 setup(
     name="spinegeneric",
     version=spinegeneric.__version__,
-    python_requires=">=3.9,<=3.13",
+    python_requires=">=3.9",
     description="Collection of cli to process data for the Spine Generic project.",
     url="https://spine-generic.rtfd.io",
     author="NeuroPoly Lab, Polytechnique Montreal",


### PR DESCRIPTION
Python 3.7 officially reached end-of-life in June 2023, and 3.8 reached end-of-life two days ago. Meanwhile, 3.12 and 3.13 are the current most-supported versions.

See: https://devguide.python.org/versions/

Fixes https://github.com/spine-generic/spine-generic/issues/242.