### PR TITLE
Get rid of `str.strip`, `str.rstrip` bugs

### DIFF
--- a/src/spinegeneric/cli/copy_to_derivatives.py
+++ b/src/spinegeneric/cli/copy_to_derivatives.py
@@ -21,7 +21,6 @@ def get_parser():
         "copied files should share a common suffix as in sub-xxx_SUFFIX.nii.gz (e.g., "
         "T1w_RPI_r_seg_labeled). If the derivatives folder does not exist, it will be created",
         formatter_class=sg.utils.SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"),
     )
     parser.add_argument(
         "-path-in",

--- a/src/spinegeneric/cli/manual_correction.py
+++ b/src/spinegeneric/cli/manual_correction.py
@@ -32,7 +32,6 @@ def get_parser():
         description="Manual correction of spinal cord and gray matter segmentation and vertebral labeling. "
         "Manually corrected files are saved under derivatives/ folder (BIDS standard).",
         formatter_class=sg.utils.SmartFormatter,
-        prog=os.path.basename(__file__).strip(".py"),
     )
     parser.add_argument(
         "-config",
@@ -145,7 +144,7 @@ def create_json(fname_nifti, name_rater):
     :return:
     """
     metadata = {"Author": name_rater, "Date": time.strftime("%Y-%m-%d %H:%M:%S")}
-    fname_json = fname_nifti.rstrip(".nii").rstrip(".nii.gz") + ".json"
+    fname_json = fname_nifti.removesuffix(".nii").removesuffix(".nii.gz") + ".json"
     with open(fname_json, "w") as outfile:
         json.dump(metadata, outfile, indent=4)
 

--- a/src/spinegeneric/cli/package_for_correction.py
+++ b/src/spinegeneric/cli/package_for_correction.py
@@ -27,7 +27,6 @@ def get_parser():
         "convenient to generate a package of the files that need correction to be able to only copy these "
         "files locally, instead of copying the ~20GB of total processed files.",
         formatter_class=sg.utils.SmartFormatter,
-        prog=os.path.basename(__file__).rstrip(".py"),
     )
     parser.add_argument(
         "-config",

--- a/src/spinegeneric/cli/populate_derivatives.py
+++ b/src/spinegeneric/cli/populate_derivatives.py
@@ -40,7 +40,6 @@ def get_parser():
         "Go to the directory that includes all the manual corrections (they should all be present in the "
         "./ folder) and run:",
         formatter_class=sg.utils.SmartFormatter,
-        prog=os.path.basename(__file__).rstrip(".py"),
     )
     parser.add_argument(
         "-path-out",


### PR DESCRIPTION
For the `prog=` cases, it's unnecessary because the entry points from `pip install` are all `sg_*` names without a `.py` suffix already.

For the file name extension manipulation, the intended function is `str.removesuffix`, which removes the given string from the end if present.

(I didn't dare touch more of the code, since there are essentially no tests, and I've never had to run the scripts, so I don't know what the assumptions or expected outcomes are.)